### PR TITLE
chore(ci): CS-6866: improved release workflow

### DIFF
--- a/.github/release.clj
+++ b/.github/release.clj
@@ -1,0 +1,214 @@
+#!/usr/bin/env bb
+(require '[babashka.fs :as fs]
+         '[babashka.process :refer [shell]]
+         '[clojure.string :as str])
+
+(def repo-dir (str (fs/parent (fs/parent *file*))))
+(def changelog-path (fs/path repo-dir "CHANGELOG.md"))
+(def gradle-properties-path (fs/path repo-dir "gradle.properties"))
+(def section-header-pattern #"^(##|###) \[")
+
+(defn fail [message]
+  (binding [*out* *err*]
+    (println message))
+  (System/exit 1))
+
+(defn process-message [result]
+  (let [stderr (or (:err result) "")
+        stdout (or (:out result) "")]
+    (if (seq stderr) stderr stdout)))
+
+(defn sh
+  [& args]
+  (let [result (apply shell {:dir repo-dir :out :string :err :string :continue true} args)]
+    (if (zero? (:exit result))
+      (str/trimr (or (:out result) ""))
+      (fail (str (process-message result) "\ncommand failed: " (str/join " " args))))))
+
+(defn command-available? [command]
+  (zero? (:exit (shell {:dir repo-dir :out :string :err :string :continue true} command "--version"))))
+
+(defn trim-blank-lines [lines]
+  (->> lines
+       (drop-while str/blank?)
+       reverse
+       (drop-while str/blank?)
+       reverse
+       vec))
+
+(defn split-lines [content]
+  (vec (str/split-lines content)))
+
+(defn join-lines [lines]
+  (str (str/join "\n" lines) "\n"))
+
+(defn next-section-index [lines start-index]
+  (or (some (fn [idx]
+              (when (re-find section-header-pattern (nth lines idx))
+                idx))
+            (range (inc start-index) (count lines)))
+      (count lines)))
+
+(defn find-section [lines header-pattern]
+  (when-let [start-index (first (keep-indexed (fn [idx line]
+                                                (when (re-find header-pattern line)
+                                                  idx))
+                                              lines))]
+    (let [end-index (next-section-index lines start-index)]
+      {:start-index start-index
+       :end-index end-index
+       :body-lines (subvec lines (inc start-index) end-index)})))
+
+(defn changelog-lines []
+  (split-lines (slurp (str changelog-path))))
+
+(defn unreleased-section []
+  (or (find-section (changelog-lines) #"^## \[Unreleased\]\s*$")
+      (fail "CHANGELOG.md is missing the [Unreleased] section.")))
+
+(defn version-section [version]
+  (or (find-section (changelog-lines)
+                    (re-pattern (str "^### \\[" (java.util.regex.Pattern/quote version) "\\](?: - .+)?$")))
+      (fail (str "CHANGELOG.md is missing the section for " version "."))))
+
+(defn section-body [section]
+  (trim-blank-lines (:body-lines section)))
+
+(defn section-text [section]
+  (let [body (section-body section)]
+    (if (seq body)
+      (join-lines body)
+      "")))
+
+(defn ensure-clean-worktree []
+  (when (seq (sh "git" "status" "--short"))
+    (fail "Release flow requires a clean git worktree.")))
+
+(defn ensure-tag-missing [tag]
+  (when (seq (sh "git" "tag" "--list" tag))
+    (fail (str "Tag already exists: " tag))))
+
+(defn update-plugin-version [version]
+  (let [updated (str/replace (slurp (str gradle-properties-path))
+                             #"(?m)^pluginVersion\s*=\s*.*$"
+                             (str "pluginVersion = " version))]
+    (spit (str gradle-properties-path) updated)))
+
+(defn promote-unreleased [version]
+  (let [lines (changelog-lines)
+        {:keys [start-index end-index body-lines]} (unreleased-section)
+        unreleased-lines (trim-blank-lines body-lines)
+        prefix (subvec lines 0 start-index)
+        suffix (vec (drop-while str/blank? (subvec lines end-index)))
+        version-header (str "### [" version "] - " (str (java.time.LocalDate/now)))
+        new-lines (vec (concat prefix
+                               ["## [Unreleased]" "" version-header]
+                               unreleased-lines
+                               [""]
+                               suffix))]
+    (spit (str changelog-path) (join-lines new-lines))))
+
+(defn default-notes [version]
+  (str "Release " version))
+
+(defn test-default-notes [version]
+  (str "Test release " version))
+
+(defn shell-quote [value]
+  (if (fs/windows?)
+    (str "\"" (str/replace value "\"" "\\\"") "\"")
+    (str "'" (str/replace value "'" "'\"'\"'") "'")))
+
+(defn open-in-editor [path]
+  (let [editor (or (System/getenv "VISUAL")
+                   (System/getenv "EDITOR")
+                   (when (command-available? "code") "code --wait"))]
+    (when-not editor
+      (fail "Set VISUAL or EDITOR, or install `code` on PATH, before running the release command."))
+    (let [result (shell {:dir repo-dir :continue true :inherit true :shell true}
+                        (str editor " " (shell-quote (str path))))]
+      (when-not (zero? (:exit result))
+        (fail "Editor command failed.")))))
+
+(defn commit-and-tag [version tag-message]
+  (sh "git" "add" "--" (str gradle-properties-path) (str changelog-path))
+  (sh "git" "commit" "-m" (str "chore(release): v" version))
+  (sh "git" "tag" "-a" (str "v" version) "-m" tag-message))
+
+(defn tag-test-release [version tag-message]
+  (sh "git" "tag" "-a" (str "v" version) "-m" tag-message))
+
+(defn short-sha []
+  (sh "git" "rev-parse" "--short" "HEAD"))
+
+(defn base-plugin-version []
+  (or (second (re-find #"(?m)^pluginVersion\s*=\s*(.+)$" (slurp (str gradle-properties-path))))
+      (fail "Could not read pluginVersion from gradle.properties.")))
+
+(defn parse-version [version]
+  (if-let [[_ major minor patch] (re-matches #"(\d+)\.(\d+)\.(\d+)" version)]
+    [(Long/parseLong major) (Long/parseLong minor) (Long/parseLong patch)]
+    (fail (str "Expected base plugin version in x.y.z format, got " version "."))))
+
+(defn increment-version [version bump]
+  (let [[major minor patch] (parse-version version)]
+    (case bump
+      "major" (str (inc major) ".0.0")
+      "minor" (str major "." (inc minor) ".0")
+      "patch" (str major "." minor "." (inc patch))
+      (fail "Usage: make bump-version BUMP=patch|minor|major"))))
+
+(defn bump-version [bump]
+  (let [version (increment-version (base-plugin-version) bump)]
+    (update-plugin-version version)
+    (println (str "Updated base plugin version to " version ".")))
+  (println "Commit gradle.properties when you are ready."))
+
+(defn stable-release []
+  (ensure-clean-worktree)
+  (let [version (base-plugin-version)]
+    (ensure-tag-missing (str "v" version))
+  (promote-unreleased version)
+  (open-in-editor changelog-path)
+  (let [notes (str/trim (section-text (version-section version)))
+        tag-message (if (seq notes) notes (default-notes version))]
+    (commit-and-tag version tag-message)
+    (println (str "Created release commit and tag v" version "."))
+    (println "Push with: git push --follow-tags"))))
+
+(defn temp-notes-path [version]
+  (fs/create-temp-file {:prefix (str "codescene-release-" version "-")
+                        :suffix ".md"}))
+
+(defn test-release []
+  (ensure-clean-worktree)
+  (let [version (str (base-plugin-version) "-test." (short-sha))
+        tag (str "v" version)]
+    (ensure-tag-missing tag)
+    (let [notes-path (temp-notes-path version)
+          notes (str/trim (section-text (unreleased-section)))]
+      (spit (str notes-path) (str (if (seq notes) notes (test-default-notes version)) "\n"))
+      (try
+        (open-in-editor notes-path)
+        (let [tag-message (str/trim (slurp (str notes-path)))]
+          (tag-test-release version (if (seq tag-message) tag-message (test-default-notes version)))
+          (println (str "Created test release tag " tag "."))
+          (println "Push with: git push --follow-tags"))
+        (finally
+          (fs/delete-if-exists notes-path))))))
+
+(defn print-notes [mode value]
+  (case mode
+    "unreleased" (print (section-text (unreleased-section)))
+    "version" (print (section-text (version-section value)))
+    (fail "Usage: bb .github/release.clj notes unreleased | notes version <version>")))
+
+(let [[command arg1 arg2] *command-line-args*]
+  (case command
+    "bump-version" (if (seq arg1)
+                     (bump-version arg1)
+                     (fail "Usage: bb .github/release.clj bump-version <patch|minor|major>"))
+    "stable" (stable-release)
+    "test" (test-release)
+    "notes" (print-notes arg1 arg2)
+    (fail "Usage: bb .github/release.clj bump-version <patch|minor|major> | stable | test | notes unreleased | notes version <version>")))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,8 @@
-# GitHub Actions Workflow is created for testing and preparing the plugin release in the following steps:
+# GitHub Actions Workflow is created for testing the plugin in the following steps:
 # - Validate Gradle Wrapper.
 # - Run 'test' and 'verifyPlugin' tasks.
 # - Run the 'buildPlugin' task and prepare artifact for further tests.
 # - Run the 'runPluginVerifier' task.
-# - Create a draft release.
 #
 # The workflow is triggered on push and pull_request events.
 #
@@ -287,38 +286,3 @@ jobs:
           name: Dependency check report
           path: ${{github.workspace}}/reports/dependency-check-report.html
 
-  # Prepare a draft release for GitHub Releases page for the manual verification
-  # If accepted and published, release workflow would be triggered
-  releaseDraft:
-    name: Release draft
-    if: github.event_name != 'pull_request'
-    needs: [build, test, verify, dependency-check]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      # Check out the current repository
-      - name: Fetch Sources
-        uses: actions/checkout@v4
-
-      # Remove old release drafts by using the curl request for the available releases with a draft flag
-      - name: Remove Old Release Drafts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/{owner}/{repo}/releases \
-            --jq '.[] | select(.draft == true) | .id' \
-            | xargs -I '{}' gh api -X DELETE repos/{owner}/{repo}/releases/{}
-
-      # Create a new release draft which is not publicly visible and requires manual acceptance
-      - name: Create Release Draft
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "v${{ needs.build.outputs.version }}" \
-            --draft \
-            --title "v${{ needs.build.outputs.version }}" \
-            --notes "$(cat << 'EOM'
-          ${{ needs.build.outputs.changelog }}
-          EOM
-          )"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,8 @@
-# GitHub Actions Workflow created for handling the release process based on the draft release prepared with the Build workflow.
-# Running the publishPlugin task requires all following secrets to be provided: PUBLISH_TOKEN, PRIVATE_KEY, PRIVATE_KEY_PASSWORD, CERTIFICATE_CHAIN.
-# See https://plugins.jetbrains.com/docs/intellij/plugin-signing.html for more information.
-
 name: Release
 on:
-  release:
-    types: [prereleased, released]
+  push:
+    tags:
+      - "v*"
 
 env:
   GH_USERNAME: ${{ secrets.GH_USERNAME }}
@@ -13,73 +10,76 @@ env:
   CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN: ${{ secrets.CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN }}
 
 jobs:
-
-  # Prepare and publish the plugin to JetBrains Marketplace repository
   release:
-    name: Publish Plugin
+    name: Publish Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
-
-      # Free GitHub Actions Environment Disk Space
       - name: Maximize Build Space
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true
           large-packages: true
 
-      # Check out the current repository
       - name: Fetch Sources
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
 
-      # Set up Java environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 17
 
-      # Setup Gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      # Set environment variables
-      - name: Export Properties
-        id: properties
+      - name: Resolve Release Metadata
+        id: release
         shell: bash
         run: |
-          CHANGELOG="$(cat << 'EOM' | sed -e 's/^[[:space:]]*$//g' -e '/./,$!d'
-          ${{ github.event.release.body }}
-          EOM
-          )"
-          
-          echo "changelog<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          VERSION="${GITHUB_REF_NAME#v}"
+          IS_TEST=false
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
 
-      # Update the Unreleased section with the current release note
-      - name: Patch Changelog
-        if: ${{ steps.properties.outputs.changelog != '' }}
-        env:
-          CHANGELOG: ${{ steps.properties.outputs.changelog }}
-        run: |
-          ./gradlew patchChangelog --release-note="$CHANGELOG"
+          if [[ "$VERSION" == *"-test."* ]]; then
+            IS_TEST=true
+          fi
 
-      # Publish the plugin to JetBrains Marketplace
+          git tag -l --format='%(contents)' "$GITHUB_REF_NAME" > "$NOTES_FILE"
+
+          if [ ! -s "$NOTES_FILE" ]; then
+            if [ "$IS_TEST" = true ]; then
+              echo "Test release $VERSION" > "$NOTES_FILE"
+            else
+              echo "Release $VERSION" > "$NOTES_FILE"
+            fi
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "is_test=$IS_TEST" >> "$GITHUB_OUTPUT"
+          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Build Plugin
+        run: ./gradlew buildPlugin -PreleaseVersion=${{ steps.release.outputs.version }} -PFEATURE_CWF_DEVMODE=${{ secrets.FEATURE_CWF_DEVMODE }}
+
       - name: Publish Plugin
+        if: ${{ steps.release.outputs.is_test != 'true' }}
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
           CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
-        run: ./gradlew publishPlugin -PFEATURE_CWF_DEVMODE=${{ secrets.FEATURE_CWF_DEVMODE }}
+        run: ./gradlew publishPlugin -PreleaseVersion=${{ steps.release.outputs.version }} -PFEATURE_CWF_DEVMODE=${{ secrets.FEATURE_CWF_DEVMODE }}
 
-      # Upload artifact as a release asset
-      - name: Upload Release Asset
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body_path: ${{ steps.release.outputs.notes_file }}
+          prerelease: ${{ steps.release.outputs.is_test == 'true' }}
+          files: ./build/distributions/*

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 BB := bb
 ifeq ($(OS),Windows_NT)
 GRADLEW := .\gradlew.bat
+NULL := NUL
 else
 GRADLEW := ./gradlew
+NULL := /dev/null
 endif
 
-.PHONY: install-cli check-bb build test format format-check delta iter coverage-summary
+.PHONY: install-cli check-bb build test format format-check delta iter coverage-summary bump-version release test-release
 
 install-cli: check-bb
 	@$(BB) -f .github/install-cli.clj
 
 check-bb:
-	@$(BB) --version > /dev/null 2>&1
+	@$(BB) --version > $(NULL) 2>&1
 
 KT_FILES := $(wildcard src/main/kotlin/**/*.kt) \
             $(wildcard src/test/kotlin/**/*.kt) \
@@ -42,3 +44,12 @@ coverage-summary: check-bb
 	@$(BB) -f .github/coverage-summary.clj
 
 iter: format-check delta test
+
+bump-version: check-bb
+	@$(BB) .github/release.clj bump-version "$(BUMP)"
+
+release: check-bb
+	@$(BB) .github/release.clj stable
+
+test-release: check-bb
+	@$(BB) .github/release.clj test

--- a/README.md
+++ b/README.md
@@ -100,6 +100,45 @@ The Makefile provides development targets for build, test, format, and CodeScene
 | `make delta`       | Run CodeScene delta analysis (requires `cs` CLI)         |
 | `make install-cli` | Install CodeScene CLI (`cs`)                             |
 | `make iter`        | Run format-check, delta, build, and test                 |
+| `make bump-version BUMP=patch|minor|major` | Increment the base plugin version |
+| `make release`     | Prepare a stable release commit and tag                  |
+| `make test-release` | Create a tagged test release from `HEAD`                |
+
+### Release commands
+
+The release flow is tag-driven. Prepare the release locally, then push the annotated tag and let GitHub Actions build from that tag.
+
+- `make bump-version BUMP=minor`
+  - increments the current base version in `gradle.properties`
+  - does not create a commit, tag, or GitHub release
+  - lets the branch move to the next planned stable base version before any release is cut
+- `make release`
+  - uses the existing base version from `gradle.properties`
+  - moves the `CHANGELOG.md` `Unreleased` notes into that version
+  - opens `CHANGELOG.md` for manual cleanup
+  - creates a release commit and an annotated `v<baseVersion>` tag
+- `make test-release`
+  - keeps `gradle.properties` unchanged
+  - derives a version like `<baseVersion>-test.<shortSha>`
+  - opens a temporary release-notes file for manual cleanup
+  - creates an annotated `v<baseVersion>-test.<shortSha>` tag on the current commit
+
+Push prepared tags with:
+
+```bash
+git push --follow-tags
+```
+
+Set `VISUAL` or `EDITOR`, or make sure `code` is available on `PATH`, before running the release commands.
+
+### Example release checklist
+
+1. Start the next release line with `make bump-version BUMP=minor` or `make bump-version BUMP=major`.
+2. Commit the base version change when appropriate for the branch.
+3. Create GitHub-only tester drops during development with `make test-release`, then `git push --follow-tags`.
+4. When the release is ready, run `make release`.
+5. Review and clean up `CHANGELOG.md` in the editor that opens.
+6. Push the release commit and tag with `git push --follow-tags`.
 
 ### Run the plugin
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,9 @@ plugins {
 }
 
 group = providers.gradleProperty("pluginGroup").get()
-version = providers.gradleProperty("pluginVersion").get()
+val basePluginVersion = providers.gradleProperty("pluginVersion")
+val effectivePluginVersion = providers.gradleProperty("releaseVersion").orElse(basePluginVersion)
+version = effectivePluginVersion.get()
 
 val codeSceneExtensionAPIVersion = providers.gradleProperty("codeSceneExtensionAPIVersion").get()
 val codeSceneRepository = providers.gradleProperty("codeSceneRepository").get()
@@ -85,7 +87,7 @@ dependencies {
 // Configure IntelliJ Platform Gradle Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html
 intellijPlatform {
     pluginConfiguration {
-        version = providers.gradleProperty("pluginVersion")
+        version = effectivePluginVersion
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         description =
@@ -104,7 +106,7 @@ intellijPlatform {
         val changelog = project.changelog // local variable for configuration cache compatibility
         // Get the latest available change notes from the changelog file
         changeNotes =
-            providers.gradleProperty("pluginVersion").map { pluginVersion ->
+            effectivePluginVersion.map { pluginVersion ->
                 with(changelog) {
                     renderItem(
                         (getOrNull(pluginVersion) ?: getUnreleased())
@@ -133,7 +135,7 @@ intellijPlatform {
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
         channels =
-            providers.gradleProperty("pluginVersion")
+            effectivePluginVersion
                 .map { listOf(it.substringAfter('-', "").ifEmpty { "default" }) }
         hidden = true
     }
@@ -186,10 +188,6 @@ changelog {
 tasks {
     wrapper {
         gradleVersion = providers.gradleProperty("gradleVersion").get()
-    }
-
-    publishPlugin {
-        dependsOn(patchChangelog)
     }
 
     runIde {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.codescene.jetbrains
 pluginName = CodeScene
 pluginRepositoryUrl = https://github.com/codescene-oss/codescene-jetbrains
 # SemVer format -> https://semver.org
-pluginVersion = 0.4.2
+pluginVersion = 0.5.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233


### PR DESCRIPTION
Improved release workflow. 

Separated version bump, test release and release into separate make commands. This enables us to create github releases, with a pre-release suffix, separated from creating a "real" release, intended for publish to marketplace

`make bump-version BUMP=patch|minor|major` - only bumps the plugin version
`make test-release` creates a tag with the current plugin version, + a test suffix, that gets picked up by a github action when pushed, and creates the github release
`make release` - creates a tag with the current plugin version, that gets picked up by a github action when pushed, and creates the github release