### PR TITLE
fix: CS-6869: multiple code smells per function code vision

### DIFF
--- a/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/CodeSceneCodeVisionProvider.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/CodeSceneCodeVisionProvider.kt
@@ -9,17 +9,17 @@ import com.codescene.jetbrains.core.util.CodeVisionAction
 import com.codescene.jetbrains.core.util.CodeVisionDecision
 import com.codescene.jetbrains.core.util.CodeVisionDecisionInput
 import com.codescene.jetbrains.core.util.defaultCodeVisionProviderIds
-import com.codescene.jetbrains.core.util.getCodeSmellsByCategory
+import com.codescene.jetbrains.core.util.formatCodeSmellMessage
 import com.codescene.jetbrains.core.util.resolveCodeVisionDecision
 import com.codescene.jetbrains.platform.api.CachedReviewService
 import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
 import com.codescene.jetbrains.platform.icons.CodeSceneIcons.CODE_SMELL
 import com.codescene.jetbrains.platform.util.Log
-import com.codescene.jetbrains.platform.util.getTextRange
 import com.codescene.jetbrains.platform.util.handleOpenDocs
 import com.codescene.jetbrains.platform.util.isFileSupported
 import com.intellij.codeInsight.codeVision.CodeVisionAnchorKind
 import com.intellij.codeInsight.codeVision.CodeVisionEntry
+import com.intellij.codeInsight.codeVision.CodeVisionEntryExtraActionModel
 import com.intellij.codeInsight.codeVision.CodeVisionProvider
 import com.intellij.codeInsight.codeVision.CodeVisionRelativeOrdering
 import com.intellij.codeInsight.codeVision.CodeVisionState
@@ -32,6 +32,8 @@ import com.intellij.openapi.util.TextRange
 @Suppress("UnstableApiUsage")
 abstract class CodeSceneCodeVisionProvider : CodeVisionProvider<Unit> {
     companion object {
+        private const val SMELL_EXTRA_ACTION_MARKER = ".smell."
+
         fun getProviders(): List<String> = defaultCodeVisionProviderIds
     }
 
@@ -47,6 +49,17 @@ abstract class CodeSceneCodeVisionProvider : CodeVisionProvider<Unit> {
 
     override fun precomputeOnUiThread(editor: Editor) {
         // Precomputations on the UI thread are unnecessary in this context, so this is left intentionally empty.
+    }
+
+    override fun handleExtraAction(
+        editor: Editor,
+        textRange: TextRange,
+        actionId: String,
+    ) {
+        val index = parseSmellExtraActionIndex(actionId) ?: return
+        val smells = smellsAtTextRange(editor, textRange) ?: return
+        val smell = smells.getOrNull(index) ?: return
+        handleLensClick(editor, smell)
     }
 
     override fun computeCodeVision(
@@ -151,18 +164,65 @@ abstract class CodeSceneCodeVisionProvider : CodeVisionProvider<Unit> {
             return arrayListOf()
         }
         val lenses = ArrayList<Pair<TextRange, CodeVisionEntry>>()
-        for (category in categories) {
-            getCodeSmellsByCategory(result, category).forEach { smell ->
-                val range =
-                    getTextRange(smell.highlightRange.startLine to smell.highlightRange.endLine, editor.document)
-                val entry = getCodeVisionEntry(smell)
-                lenses.add(range to entry)
-            }
+        val pairs = collectSmellsWithHighlightRangesForVision(editor, result, categories)
+        val grouped = groupReviewSmellsByHighlightRange(pairs)
+        for ((range, smells) in grouped) {
+            lenses.add(range to codeVisionEntryForSmells(smells))
         }
         return lenses
     }
 
-    private fun getCodeVisionEntry(codeSmell: CodeVisionCodeSmell): ClickableTextCodeVisionEntry =
+    private fun smellsAtTextRange(
+        editor: Editor,
+        textRange: TextRange,
+    ): List<CodeVisionCodeSmell>? {
+        val categories = categoriesForLenses()
+        if (categories.isEmpty()) {
+            return null
+        }
+        val project = editor.project ?: return null
+        val serviceProvider = CodeSceneProjectServiceProvider.getInstance(project)
+        val query = ReviewCacheQuery(editor.document.text, editor.virtualFile.path)
+        val review = serviceProvider.reviewCacheService.get(query) ?: return null
+        val pairs = collectSmellsWithHighlightRangesForVision(editor, review, categories)
+        return groupReviewSmellsByHighlightRange(pairs)
+            .firstOrNull { (r, _) -> r == textRange }
+            ?.second
+    }
+
+    private fun parseSmellExtraActionIndex(actionId: String): Int? {
+        val marker = "${id}$SMELL_EXTRA_ACTION_MARKER"
+        if (!actionId.startsWith(marker)) {
+            return null
+        }
+        return actionId.removePrefix(marker).toIntOrNull()
+    }
+
+    private fun smellExtraActionId(index: Int): String = "${id}$SMELL_EXTRA_ACTION_MARKER$index"
+
+    private fun codeVisionEntryForSmells(smells: List<CodeVisionCodeSmell>): ClickableTextCodeVisionEntry {
+        require(smells.isNotEmpty())
+        if (smells.size == 1) {
+            return singleSmellCodeVisionEntry(smells.first())
+        }
+        val text = smells.joinToString(" | ") { it.category }
+        val tooltip = smells.joinToString("\n") { formatCodeSmellMessage(it.category, it.details) }
+        val extraActions =
+            smells.mapIndexed { index, smell ->
+                CodeVisionEntryExtraActionModel(smell.category, smellExtraActionId(index))
+            }
+        return ClickableTextCodeVisionEntry(
+            text,
+            id,
+            { mouseEvent, sourceEditor -> showSmellDocumentationChooser(mouseEvent, sourceEditor, smells) },
+            CODE_SMELL,
+            text,
+            tooltip,
+            extraActions,
+        )
+    }
+
+    private fun singleSmellCodeVisionEntry(codeSmell: CodeVisionCodeSmell): ClickableTextCodeVisionEntry =
         ClickableTextCodeVisionEntry(
             codeSmell.category,
             id,

--- a/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/CodeVisionSmellDocsChooser.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/CodeVisionSmellDocsChooser.kt
@@ -1,0 +1,54 @@
+package com.codescene.jetbrains.platform.editor.codeVision
+
+import com.codescene.jetbrains.core.models.CodeVisionCodeSmell
+import com.codescene.jetbrains.core.models.DocsEntryPoint
+import com.codescene.jetbrains.core.util.formatCodeSmellMessage
+import com.codescene.jetbrains.platform.UiLabelsBundle
+import com.codescene.jetbrains.platform.util.handleOpenDocs
+import com.intellij.ide.DataManager
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.ui.awt.RelativePoint
+import java.awt.event.MouseEvent
+
+internal fun showSmellDocumentationChooser(
+    mouseEvent: MouseEvent?,
+    editor: Editor,
+    smells: List<CodeVisionCodeSmell>,
+) {
+    val group = DefaultActionGroup()
+    for (smell in smells) {
+        group.add(
+            object : AnAction(formatCodeSmellMessage(smell.category, smell.details)) {
+                override fun getActionUpdateThread() = ActionUpdateThread.BGT
+
+                override fun actionPerformed(e: AnActionEvent) {
+                    handleOpenDocs(editor, smell, DocsEntryPoint.CODE_VISION)
+                }
+            },
+        )
+    }
+    val title = UiLabelsBundle.message("codeVisionChooseCodeSmell")
+    val context = DataManager.getInstance().getDataContext(editor.contentComponent)
+    val popup =
+        JBPopupFactory.getInstance().createActionGroupPopup(
+            title,
+            group,
+            context,
+            JBPopupFactory.ActionSelectionAid.NUMBERING,
+            true,
+        )
+    ApplicationManager.getApplication().invokeLater {
+        if (mouseEvent != null) {
+            val component = mouseEvent.component ?: editor.contentComponent
+            popup.show(RelativePoint(component, mouseEvent.point))
+        } else {
+            popup.showInBestPositionFor(editor)
+        }
+    }
+}

--- a/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/ReviewSmellCodeVisionGrouping.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/ReviewSmellCodeVisionGrouping.kt
@@ -1,0 +1,50 @@
+package com.codescene.jetbrains.platform.editor.codeVision
+
+import com.codescene.data.review.Review
+import com.codescene.jetbrains.core.models.CodeVisionCodeSmell
+import com.codescene.jetbrains.core.util.CodeVisionSmellCategories
+import com.codescene.jetbrains.core.util.getCodeSmellsByCategory
+import com.codescene.jetbrains.platform.util.getTextRange
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.TextRange
+
+internal fun collectSmellsWithHighlightRangesForVision(
+    editor: Editor,
+    result: Review?,
+    categories: List<String>,
+): List<Pair<TextRange, CodeVisionCodeSmell>> {
+    val out = ArrayList<Pair<TextRange, CodeVisionCodeSmell>>()
+    for (category in categories) {
+        for (smell in getCodeSmellsByCategory(result, category)) {
+            val range =
+                getTextRange(smell.highlightRange.startLine to smell.highlightRange.endLine, editor.document)
+            out.add(range to smell)
+        }
+    }
+    return out
+}
+
+internal fun groupReviewSmellsByHighlightRange(
+    pairs: List<Pair<TextRange, CodeVisionCodeSmell>>,
+): List<Pair<TextRange, List<CodeVisionCodeSmell>>> {
+    val byRange = LinkedHashMap<TextRange, LinkedHashSet<CodeVisionCodeSmell>>()
+    for ((range, smell) in pairs) {
+        byRange.getOrPut(range) { linkedSetOf() }.add(smell)
+    }
+    val order = CodeVisionSmellCategories.orderedForDisplay
+    return byRange.map { (range, set) ->
+        val comparator =
+            compareBy<CodeVisionCodeSmell> { smell ->
+                smellCategoryOrderIndexForVision(order, smell)
+            }.thenBy { it.category }
+        range to set.sortedWith(comparator)
+    }
+}
+
+private fun smellCategoryOrderIndexForVision(
+    order: List<String>,
+    smell: CodeVisionCodeSmell,
+): Int {
+    val index = order.indexOf(smell.category)
+    return if (index < 0) Int.MAX_VALUE else index
+}

--- a/src/main/resources/messages/UiLabelsBundle.properties
+++ b/src/main/resources/messages/UiLabelsBundle.properties
@@ -7,6 +7,7 @@ editor=Editor
 serverUrl=Server Url
 cloudConnection=Cloud Connection
 enableCodeLensesComment=Show Code Vision for review diagnostics
+codeVisionChooseCodeSmell=Open documentation
 enableAutoRefactorComment=Enable CodeScene ACE
 aceAuthTokenComment=Authentication token for CodeScene ACE.
 #About Tab


### PR DESCRIPTION
The Code Vision provider now support if a function has multiple code smells, it shows them all, and adds a menu to open each code smells documentation.