### PR TITLE
Implement GitChangeObserver

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/IOpenFilesObserver.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/IOpenFilesObserver.kt
@@ -1,0 +1,5 @@
+package com.codescene.jetbrains.core.contracts
+
+interface IOpenFilesObserver {
+    fun getAllVisibleFileNames(): Set<String>
+}

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/ISavedFilesTracker.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/ISavedFilesTracker.kt
@@ -1,0 +1,5 @@
+package com.codescene.jetbrains.core.contracts
+
+interface ISavedFilesTracker {
+    fun getSavedFiles(): Set<String>
+}

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitChangeObserver.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitChangeObserver.kt
@@ -1,0 +1,196 @@
+package com.codescene.jetbrains.core.git
+
+import com.codescene.jetbrains.core.contracts.IFileSystem
+import com.codescene.jetbrains.core.contracts.IGitChangeLister
+import com.codescene.jetbrains.core.contracts.IOpenFilesObserver
+import com.codescene.jetbrains.core.contracts.ISavedFilesTracker
+import java.io.File
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+enum class FileEventType { CREATE, CHANGE, DELETE }
+
+data class FileEvent(val type: FileEventType, val path: String)
+
+class GitChangeObserver(
+    private val gitChangeLister: IGitChangeLister,
+    private val savedFilesTracker: ISavedFilesTracker,
+    private val openFilesObserver: IOpenFilesObserver,
+    private val fileSystem: IFileSystem,
+    private val onFileDeleted: (String) -> Unit,
+    private val onFileChanged: suspend (String) -> Unit,
+    private val workspacePath: String,
+    private val gitRootPath: String,
+    private val batchIntervalMs: Long = 1000L,
+) {
+    private val tracker = mutableSetOf<String>()
+    private val eventQueue = mutableListOf<FileEvent>()
+    private var scheduler: ScheduledExecutorService? = null
+
+    init {
+        kotlinx.coroutines.runBlocking { populateTrackerFromRepoState() }
+    }
+
+    internal suspend fun populateTrackerFromRepoState() {
+        val changedFiles = gitChangeLister.getAllChangedFiles(gitRootPath, workspacePath, emptySet())
+        // Add all files to tracker unconditionally - this ensures HandleFileDelete works correctly.
+        // Files open in the editor are excluded from changedFiles (via OpenFilesObserver), but they
+        // still need to be tracked so that delete events are properly handled.
+        for (relativePath in changedFiles) {
+            val absolutePath = fileSystem.getAbsolutePath(workspacePath, relativePath)
+            synchronized(tracker) {
+                tracker.add(absolutePath)
+            }
+        }
+    }
+
+    fun start() {
+        dispose()
+        scheduler = Executors.newSingleThreadScheduledExecutor()
+        scheduler?.scheduleAtFixedRate(
+            { kotlinx.coroutines.runBlocking { processQueuedEvents() } },
+            batchIntervalMs,
+            batchIntervalMs,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    fun queueEvent(event: FileEvent) {
+        synchronized(eventQueue) {
+            eventQueue.add(event)
+        }
+    }
+
+    suspend fun processQueuedEvents() {
+        val events: List<FileEvent>
+        synchronized(eventQueue) {
+            events = eventQueue.toList()
+            eventQueue.clear()
+        }
+
+        if (events.isEmpty()) {
+            return
+        }
+
+        val deduplicatedEvents =
+            events
+                .groupBy { it.path }
+                .mapValues { it.value.last() }
+                .values
+                .toList()
+
+        val changedFiles = getChangedFilesVsBaseline()
+
+        for (event in deduplicatedEvents) {
+            if (event.type == FileEventType.DELETE || !isFileInChangedList(event.path, changedFiles)) {
+                handleFileDelete(event.path, changedFiles)
+            } else {
+                handleFileChange(event.path, changedFiles)
+            }
+        }
+    }
+
+    suspend fun getChangedFilesVsBaseline(): Set<String> {
+        val filesToExcludeFromHeuristic =
+            savedFilesTracker.getSavedFiles() + openFilesObserver.getAllVisibleFileNames()
+        return gitChangeLister.getAllChangedFiles(gitRootPath, workspacePath, filesToExcludeFromHeuristic)
+    }
+
+    fun removeFromTracker(filePath: String) {
+        synchronized(tracker) {
+            tracker.remove(filePath)
+        }
+    }
+
+    fun getTrackedFiles(): Set<String> {
+        synchronized(tracker) {
+            return tracker.toSet()
+        }
+    }
+
+    fun getQueuedEventCount(): Int {
+        synchronized(eventQueue) {
+            return eventQueue.size
+        }
+    }
+
+    fun dispose() {
+        scheduler?.shutdown()
+        scheduler = null
+    }
+
+    internal fun shouldProcessFile(
+        filePath: String,
+        changedFiles: Set<String>,
+    ): Boolean {
+        if (!shouldReviewFile(filePath)) {
+            return false
+        }
+        return isFileInChangedList(filePath, changedFiles)
+    }
+
+    private fun isFileInChangedList(
+        filePath: String,
+        changedFiles: Set<String>,
+    ): Boolean {
+        val relativePath = fileSystem.getRelativePath(workspacePath, filePath)
+        return changedFiles.contains(relativePath)
+    }
+
+    private suspend fun handleFileChange(
+        filePath: String,
+        changedFiles: Set<String>,
+    ) {
+        val extension = fileSystem.getExtension(filePath)
+        if (extension.isEmpty()) {
+            return
+        }
+
+        if (!shouldProcessFile(filePath, changedFiles)) {
+            return
+        }
+
+        synchronized(tracker) {
+            tracker.add(filePath)
+        }
+        onFileChanged(filePath)
+    }
+
+    private fun handleFileDelete(
+        filePath: String,
+        changedFiles: Set<String>,
+    ) {
+        synchronized(tracker) {
+            if (tracker.contains(filePath)) {
+                tracker.remove(filePath)
+                onFileDeleted(filePath)
+                return
+            }
+        }
+
+        if (shouldProcessFile(filePath, changedFiles)) {
+            onFileDeleted(filePath)
+            return
+        }
+
+        val extension = fileSystem.getExtension(filePath)
+        val isDirectory = extension.isEmpty()
+
+        if (isDirectory) {
+            val directoryPrefix =
+                if (filePath.endsWith(File.separator)) filePath else filePath + File.separator
+            val filesToDelete: List<String>
+            synchronized(tracker) {
+                filesToDelete = tracker.filter { it.startsWith(directoryPrefix) }
+            }
+
+            for (fileToDelete in filesToDelete) {
+                synchronized(tracker) {
+                    tracker.remove(fileToDelete)
+                }
+                onFileDeleted(fileToDelete)
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverIntegrationTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverIntegrationTest.kt
@@ -1,0 +1,226 @@
+package com.codescene.jetbrains.core.git
+
+import com.codescene.jetbrains.core.contracts.IFileSystem
+import com.codescene.jetbrains.core.contracts.IOpenFilesObserver
+import com.codescene.jetbrains.core.contracts.ISavedFilesTracker
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GitChangeObserverIntegrationTest {
+    private lateinit var testRepoPath: File
+    private lateinit var observer: GitChangeObserver
+    private lateinit var gitChangeLister: TestGitChangeLister
+    private var deletedFiles: MutableList<String> = mutableListOf()
+    private var changedFiles: MutableList<String> = mutableListOf()
+
+    @Before
+    fun setup() {
+        testRepoPath = Files.createTempDirectory("test-git-repo-observer").toFile()
+        GitTestSupport.initGitRepoWithExtraFiles(testRepoPath)
+
+        deletedFiles = mutableListOf()
+        changedFiles = mutableListOf()
+        gitChangeLister = TestGitChangeLister(testRepoPath)
+
+        observer =
+            GitChangeObserver(
+                gitChangeLister = gitChangeLister,
+                savedFilesTracker = NoOpSavedFilesTracker(),
+                openFilesObserver = NoOpOpenFilesObserver(),
+                fileSystem = RealFileSystem(testRepoPath.absolutePath),
+                onFileDeleted = { deletedFiles.add(it) },
+                onFileChanged = { changedFiles.add(it) },
+                workspacePath = testRepoPath.absolutePath,
+                gitRootPath = testRepoPath.absolutePath,
+            )
+    }
+
+    @After
+    fun teardown() {
+        observer.dispose()
+        testRepoPath.deleteRecursively()
+    }
+
+    private fun exec(vararg command: String): String = GitTestSupport.exec(testRepoPath, *command)
+
+    @Test
+    fun `returns empty set for clean repository`() =
+        runBlocking {
+            val changedFilesSet = observer.getChangedFilesVsBaseline()
+            assertEquals(0, changedFilesSet.size)
+        }
+
+    @Test
+    fun `detects new untracked files`() =
+        runBlocking {
+            val newFile = File(testRepoPath, "new-file.ts")
+            newFile.writeText("export const x = 1;")
+
+            val changedFilesSet = observer.getChangedFilesVsBaseline()
+
+            assertTrue(changedFilesSet.any { it.endsWith("new-file.ts") })
+        }
+
+    @Test
+    fun `detects modified files`() =
+        runBlocking {
+            val existingFile = File(testRepoPath, "existing.ts")
+            existingFile.writeText("export const modified = true;")
+
+            val changedFilesSet = observer.getChangedFilesVsBaseline()
+
+            assertTrue(changedFilesSet.any { it.endsWith("existing.ts") })
+        }
+
+    @Test
+    fun `detects staged files`() =
+        runBlocking {
+            val newFile = File(testRepoPath, "staged.py")
+            newFile.writeText("print('staged')")
+            exec("git", "add", "staged.py")
+
+            val changedFilesSet = observer.getChangedFilesVsBaseline()
+
+            assertTrue(changedFilesSet.any { it.endsWith("staged.py") })
+        }
+
+    @Test
+    fun `combines status and diff changes`() =
+        runBlocking {
+            exec("git", "checkout", "-b", "feature-branch")
+
+            val committedFile = File(testRepoPath, "committed.ts")
+            committedFile.writeText("export const foo = 1;")
+            exec("git", "add", "committed.ts")
+            exec("git", "commit", "-m", "Add committed.ts")
+
+            val uncommittedFile = File(testRepoPath, "uncommitted.ts")
+            uncommittedFile.writeText("export const bar = 2;")
+
+            val changedFilesSet = observer.getChangedFilesVsBaseline()
+
+            assertTrue(changedFilesSet.any { it.endsWith("committed.ts") })
+            assertTrue(changedFilesSet.any { it.endsWith("uncommitted.ts") })
+        }
+
+    @Test
+    fun `handles files with whitespace in names`() =
+        runBlocking {
+            val fileWithSpaces = File(testRepoPath, "my file.ts")
+            fileWithSpaces.writeText("export const x = 1;")
+
+            val changedFilesSet = observer.getChangedFilesVsBaseline()
+
+            assertTrue(changedFilesSet.any { it.contains("my file.ts") })
+        }
+
+    @Test
+    fun `gitignored files are not tracked`() =
+        runBlocking {
+            val gitignore = File(testRepoPath, ".gitignore")
+            gitignore.writeText("ignored.ts")
+            exec("git", "add", ".gitignore")
+            exec("git", "commit", "-m", "Add .gitignore")
+
+            val ignoredFile = File(testRepoPath, "ignored.ts")
+            ignoredFile.writeText("export const ignored = true;")
+
+            observer.queueEvent(FileEvent(FileEventType.CREATE, ignoredFile.absolutePath))
+            observer.processQueuedEvents()
+
+            assertFalse(observer.getTrackedFiles().contains(ignoredFile.absolutePath))
+        }
+
+    @Test
+    fun `file becomes tracked after gitignore removal`() =
+        runBlocking {
+            val gitignore = File(testRepoPath, ".gitignore")
+            gitignore.writeText("previously-ignored.ts")
+            exec("git", "add", ".gitignore")
+            exec("git", "commit", "-m", "Add .gitignore")
+
+            val previouslyIgnoredFile = File(testRepoPath, "previously-ignored.ts")
+            previouslyIgnoredFile.writeText("export const x = 1;")
+
+            observer.queueEvent(FileEvent(FileEventType.CREATE, previouslyIgnoredFile.absolutePath))
+            observer.processQueuedEvents()
+            assertFalse(observer.getTrackedFiles().contains(previouslyIgnoredFile.absolutePath))
+
+            gitignore.writeText("")
+            exec("git", "add", ".gitignore")
+            exec("git", "commit", "-m", "Clear .gitignore")
+
+            observer.queueEvent(FileEvent(FileEventType.CHANGE, previouslyIgnoredFile.absolutePath))
+            observer.processQueuedEvents()
+
+            assertTrue(observer.getTrackedFiles().contains(previouslyIgnoredFile.absolutePath))
+        }
+
+    @Test
+    fun `integration - file modification and revert cycle`() =
+        runBlocking {
+            val testFile = File(testRepoPath, "cycle-test.ts")
+            testFile.writeText("export const original = 1;")
+            exec("git", "add", "cycle-test.ts")
+            exec("git", "commit", "-m", "Add cycle-test.ts")
+
+            testFile.writeText("export const modified = 2;")
+
+            observer.queueEvent(FileEvent(FileEventType.CHANGE, testFile.absolutePath))
+            observer.processQueuedEvents()
+            assertTrue(observer.getTrackedFiles().contains(testFile.absolutePath))
+
+            testFile.writeText("export const original = 1;")
+
+            observer.queueEvent(FileEvent(FileEventType.CHANGE, testFile.absolutePath))
+            observer.processQueuedEvents()
+
+            assertFalse(observer.getTrackedFiles().contains(testFile.absolutePath))
+        }
+}
+
+private class NoOpSavedFilesTracker : ISavedFilesTracker {
+    override fun getSavedFiles(): Set<String> = emptySet()
+}
+
+private class NoOpOpenFilesObserver : IOpenFilesObserver {
+    override fun getAllVisibleFileNames(): Set<String> = emptySet()
+}
+
+private class RealFileSystem(private val basePath: String) : IFileSystem {
+    override fun readFile(path: String): String? {
+        val file = File(path)
+        return if (file.exists()) file.readText() else null
+    }
+
+    override fun fileExists(path: String): Boolean = File(path).exists()
+
+    override fun getRelativePath(
+        basePath: String,
+        filePath: String,
+    ): String {
+        val base = Paths.get(basePath).toAbsolutePath().normalize()
+        val file = Paths.get(filePath).toAbsolutePath().normalize()
+        return base.relativize(file).toString()
+    }
+
+    override fun getAbsolutePath(
+        parent: String,
+        child: String,
+    ): String = Paths.get(parent, child).toAbsolutePath().normalize().toString()
+
+    override fun getExtension(path: String): String {
+        val file = File(path)
+        return file.extension
+    }
+
+    override fun getParent(path: String): String? = File(path).parent
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverPrePopulationTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverPrePopulationTest.kt
@@ -1,0 +1,110 @@
+package com.codescene.jetbrains.core.git
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GitChangeObserverPrePopulationTest {
+    private lateinit var mockGitChangeLister: MockGitChangeLister
+    private lateinit var mockSavedFilesTracker: MockSavedFilesTracker
+    private lateinit var mockOpenFilesObserver: MockOpenFilesObserver
+    private lateinit var mockFileSystem: MockFileSystem
+    private var deletedFiles: MutableList<String> = mutableListOf()
+    private var changedFiles: MutableList<String> = mutableListOf()
+
+    private val workspacePath = "/workspace"
+    private val gitRootPath = "/workspace"
+
+    @Before
+    fun setup() {
+        deletedFiles = mutableListOf()
+        changedFiles = mutableListOf()
+        mockGitChangeLister = MockGitChangeLister()
+        mockSavedFilesTracker = MockSavedFilesTracker()
+        mockOpenFilesObserver = MockOpenFilesObserver()
+        mockFileSystem = MockFileSystem()
+    }
+
+    private fun createObserver(): GitChangeObserver =
+        GitChangeObserver(
+            gitChangeLister = mockGitChangeLister,
+            savedFilesTracker = mockSavedFilesTracker,
+            openFilesObserver = mockOpenFilesObserver,
+            fileSystem = mockFileSystem,
+            onFileDeleted = { deletedFiles.add(it) },
+            onFileChanged = { changedFiles.add(it) },
+            workspacePath = workspacePath,
+            gitRootPath = gitRootPath,
+        )
+
+    @Test
+    fun `tracker is pre-populated on construction`() {
+        mockGitChangeLister.changedFiles = setOf("src/file1.ts", "src/file2.ts")
+
+        val observer = createObserver()
+
+        val trackedFiles = observer.getTrackedFiles()
+        assertTrue(trackedFiles.contains("/workspace/src/file1.ts"))
+        assertTrue(trackedFiles.contains("/workspace/src/file2.ts"))
+        assertEquals(2, trackedFiles.size)
+    }
+
+    @Test
+    fun `pre-population converts relative paths to absolute paths`() {
+        mockGitChangeLister.changedFiles = setOf("src/file.ts")
+
+        val observer = createObserver()
+
+        val trackedFiles = observer.getTrackedFiles()
+        assertTrue(trackedFiles.contains("/workspace/src/file.ts"))
+        assertFalse(trackedFiles.contains("src/file.ts"))
+    }
+
+    @Test
+    fun `pre-populated files can be deleted without prior change event`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles = setOf("src/file.ts")
+
+            val observer = createObserver()
+
+            assertTrue(observer.getTrackedFiles().contains("/workspace/src/file.ts"))
+
+            mockGitChangeLister.changedFiles = emptySet()
+            observer.queueEvent(FileEvent(FileEventType.DELETE, "/workspace/src/file.ts"))
+            observer.processQueuedEvents()
+
+            assertFalse(observer.getTrackedFiles().contains("/workspace/src/file.ts"))
+            assertTrue(deletedFiles.contains("/workspace/src/file.ts"))
+        }
+
+    @Test
+    fun `pre-population handles empty changed files list`() {
+        mockGitChangeLister.changedFiles = emptySet()
+
+        val observer = createObserver()
+
+        assertTrue(observer.getTrackedFiles().isEmpty())
+    }
+
+    @Test
+    fun `delete event fires for file that was open in editor during init`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles = setOf("src/open-in-editor.ts")
+            mockOpenFilesObserver.files = setOf("/workspace/src/open-in-editor.ts")
+
+            val observer = createObserver()
+
+            assertTrue(observer.getTrackedFiles().contains("/workspace/src/open-in-editor.ts"))
+
+            mockGitChangeLister.changedFiles = emptySet()
+
+            observer.queueEvent(FileEvent(FileEventType.DELETE, "/workspace/src/open-in-editor.ts"))
+            observer.processQueuedEvents()
+
+            assertFalse(observer.getTrackedFiles().contains("/workspace/src/open-in-editor.ts"))
+            assertTrue(deletedFiles.contains("/workspace/src/open-in-editor.ts"))
+        }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverTest.kt
@@ -1,0 +1,203 @@
+package com.codescene.jetbrains.core.git
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GitChangeObserverTest {
+    private lateinit var observer: GitChangeObserver
+    private lateinit var mockGitChangeLister: MockGitChangeLister
+    private lateinit var mockSavedFilesTracker: MockSavedFilesTracker
+    private lateinit var mockOpenFilesObserver: MockOpenFilesObserver
+    private lateinit var mockFileSystem: MockFileSystem
+    private var deletedFiles: MutableList<String> = mutableListOf()
+    private var changedFiles: MutableList<String> = mutableListOf()
+
+    private val workspacePath = "/workspace"
+    private val gitRootPath = "/workspace"
+
+    @Before
+    fun setup() {
+        deletedFiles = mutableListOf()
+        changedFiles = mutableListOf()
+        mockGitChangeLister = MockGitChangeLister()
+        mockSavedFilesTracker = MockSavedFilesTracker()
+        mockOpenFilesObserver = MockOpenFilesObserver()
+        mockFileSystem = MockFileSystem()
+
+        observer =
+            GitChangeObserver(
+                gitChangeLister = mockGitChangeLister,
+                savedFilesTracker = mockSavedFilesTracker,
+                openFilesObserver = mockOpenFilesObserver,
+                fileSystem = mockFileSystem,
+                onFileDeleted = { deletedFiles.add(it) },
+                onFileChanged = { changedFiles.add(it) },
+                workspacePath = workspacePath,
+                gitRootPath = gitRootPath,
+            )
+    }
+
+    @Test
+    fun `tracker tracks added files`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles = setOf("test.ts")
+            observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/test.ts"))
+            observer.processQueuedEvents()
+
+            assertTrue(observer.getTrackedFiles().contains("/workspace/test.ts"))
+        }
+
+    @Test
+    fun `removeFromTracker removes file from tracking`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles = setOf("test.ts")
+            observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/test.ts"))
+            observer.processQueuedEvents()
+            assertTrue(observer.getTrackedFiles().contains("/workspace/test.ts"))
+
+            observer.removeFromTracker("/workspace/test.ts")
+
+            assertFalse(observer.getTrackedFiles().contains("/workspace/test.ts"))
+        }
+
+    @Test
+    fun `handleFileDelete removes tracked file`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles = setOf("test.ts")
+            observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/test.ts"))
+            observer.processQueuedEvents()
+            assertTrue(observer.getTrackedFiles().contains("/workspace/test.ts"))
+
+            mockGitChangeLister.changedFiles = emptySet()
+            observer.queueEvent(FileEvent(FileEventType.DELETE, "/workspace/test.ts"))
+            observer.processQueuedEvents()
+
+            assertFalse(observer.getTrackedFiles().contains("/workspace/test.ts"))
+            assertTrue(deletedFiles.contains("/workspace/test.ts"))
+        }
+
+    @Test
+    fun `handleFileDelete handles directory deletion`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles = setOf("subdir/file1.ts", "subdir/file2.ts", "other.ts")
+            observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/subdir/file1.ts"))
+            observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/subdir/file2.ts"))
+            observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/other.ts"))
+            observer.processQueuedEvents()
+
+            assertEquals(3, observer.getTrackedFiles().size)
+
+            mockFileSystem.extensionOverrides["/workspace/subdir"] = ""
+            mockGitChangeLister.changedFiles = setOf("other.ts")
+            observer.queueEvent(FileEvent(FileEventType.DELETE, "/workspace/subdir"))
+            observer.processQueuedEvents()
+
+            assertEquals(1, observer.getTrackedFiles().size)
+            assertTrue(observer.getTrackedFiles().contains("/workspace/other.ts"))
+            assertTrue(deletedFiles.contains("/workspace/subdir/file1.ts"))
+            assertTrue(deletedFiles.contains("/workspace/subdir/file2.ts"))
+        }
+
+    @Test
+    fun `shouldProcessFile rejects unsupported file types`() =
+        runBlocking {
+            val changedFilesSet = setOf("test.txt")
+            assertFalse(observer.shouldProcessFile("/workspace/test.txt", changedFilesSet))
+        }
+
+    @Test
+    fun `shouldProcessFile accepts supported file types`() =
+        runBlocking {
+            val changedFilesSet = setOf("test.ts")
+            assertTrue(observer.shouldProcessFile("/workspace/test.ts", changedFilesSet))
+        }
+
+    @Test
+    fun `handleFileChange filters files not in changed list`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles = emptySet()
+            observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/committed.ts"))
+            observer.processQueuedEvents()
+
+            assertFalse(observer.getTrackedFiles().contains("/workspace/committed.ts"))
+        }
+
+    @Test
+    fun `change event removes tracked file when no longer changed`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles = setOf("test.ts")
+            observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/test.ts"))
+            observer.processQueuedEvents()
+            assertTrue(observer.getTrackedFiles().contains("/workspace/test.ts"))
+
+            mockGitChangeLister.changedFiles = emptySet()
+            observer.queueEvent(FileEvent(FileEventType.CHANGE, "/workspace/test.ts"))
+            observer.processQueuedEvents()
+
+            assertFalse(observer.getTrackedFiles().contains("/workspace/test.ts"))
+            assertTrue(deletedFiles.contains("/workspace/test.ts"))
+        }
+
+    @Test
+    fun `events are queued instead of processed immediately`() {
+        observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/test1.ts"))
+        observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/test2.ts"))
+
+        assertEquals(2, observer.getQueuedEventCount())
+        assertTrue(observer.getTrackedFiles().isEmpty())
+    }
+
+    @Test
+    fun `getChangedFilesVsBaseline is called once per batch`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles = setOf("test1.ts", "test2.ts", "test3.ts")
+            observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/test1.ts"))
+            observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/test2.ts"))
+            observer.queueEvent(FileEvent(FileEventType.CREATE, "/workspace/test3.ts"))
+
+            val callCountBefore = mockGitChangeLister.callCount
+            observer.processQueuedEvents()
+            val callCountAfter = mockGitChangeLister.callCount
+
+            assertEquals(1, callCountAfter - callCountBefore)
+        }
+
+    @Test
+    fun `empty queue does not trigger unnecessary processing`() =
+        runBlocking {
+            val callCountBefore = mockGitChangeLister.callCount
+            observer.processQueuedEvents()
+            val callCountAfter = mockGitChangeLister.callCount
+
+            assertEquals(0, callCountAfter - callCountBefore)
+        }
+
+    @Test
+    fun `dispose cleans up resources`() {
+        observer.start()
+        observer.dispose()
+    }
+
+    @Test
+    fun `dispose cleans up scheduled executor`() {
+        observer.start()
+        observer.dispose()
+        observer.dispose()
+    }
+
+    @Test
+    fun `duplicate change events in same batch only trigger one callback`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles = setOf("test.ts")
+            observer.queueEvent(FileEvent(FileEventType.CHANGE, "/workspace/test.ts"))
+            observer.queueEvent(FileEvent(FileEventType.CHANGE, "/workspace/test.ts"))
+            observer.queueEvent(FileEvent(FileEventType.CHANGE, "/workspace/test.ts"))
+            observer.processQueuedEvents()
+
+            assertEquals(1, changedFiles.size)
+        }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverTestSupport.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverTestSupport.kt
@@ -1,0 +1,77 @@
+package com.codescene.jetbrains.core.git
+
+import com.codescene.jetbrains.core.contracts.IFileSystem
+import com.codescene.jetbrains.core.contracts.IGitChangeLister
+import com.codescene.jetbrains.core.contracts.IOpenFilesObserver
+import com.codescene.jetbrains.core.contracts.ISavedFilesTracker
+import java.nio.file.Paths
+
+class MockGitChangeLister : IGitChangeLister {
+    var changedFiles: Set<String> = emptySet()
+    var callCount: Int = 0
+
+    override suspend fun getAllChangedFiles(
+        gitRootPath: String,
+        workspacePath: String,
+        filesToExcludeFromHeuristic: Set<String>,
+    ): Set<String> {
+        callCount++
+        return changedFiles
+    }
+}
+
+class MockSavedFilesTracker : ISavedFilesTracker {
+    var files: Set<String> = emptySet()
+
+    override fun getSavedFiles(): Set<String> = files
+}
+
+class MockOpenFilesObserver : IOpenFilesObserver {
+    var files: Set<String> = emptySet()
+
+    override fun getAllVisibleFileNames(): Set<String> = files
+}
+
+class MockFileSystem : IFileSystem {
+    var extensionOverrides: MutableMap<String, String> = mutableMapOf()
+
+    override fun readFile(path: String): String? = null
+
+    override fun fileExists(path: String): Boolean = true
+
+    override fun getRelativePath(
+        basePath: String,
+        filePath: String,
+    ): String {
+        return try {
+            val base = Paths.get(basePath)
+            val file = Paths.get(filePath)
+            base.relativize(file).toString()
+        } catch (e: IllegalArgumentException) {
+            filePath
+        }
+    }
+
+    override fun getAbsolutePath(
+        parent: String,
+        child: String,
+    ): String = "$parent/$child"
+
+    override fun getExtension(path: String): String {
+        if (extensionOverrides.containsKey(path)) {
+            return extensionOverrides[path]!!
+        }
+        val lastDot = path.lastIndexOf('.')
+        val lastSep = path.lastIndexOf('/')
+        return if (lastDot > lastSep && lastDot >= 0) {
+            path.substring(lastDot + 1)
+        } else {
+            ""
+        }
+    }
+
+    override fun getParent(path: String): String? {
+        val lastSep = path.lastIndexOf('/')
+        return if (lastSep > 0) path.substring(0, lastSep) else null
+    }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeLister.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeLister.kt
@@ -149,7 +149,7 @@ class TestGitChangeLister(private val testRepoPath: File) : IGitChangeLister {
     private fun getMergeBase(gitRootPath: String): String? {
         val currentBranch = exec("git", "rev-parse", "--abbrev-ref", "HEAD").trim()
 
-        val mainBranchNames = listOf("main", "master", "develop", "trunk", "dev")
+        val mainBranchNames = listOf("main", "master", "develop", "trunk", "dev", "development")
         if (mainBranchNames.any { it.equals(currentBranch, ignoreCase = true) }) {
             return exec("git", "rev-parse", "HEAD").trim()
         }

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeListerForCommitted.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeListerForCommitted.kt
@@ -50,7 +50,7 @@ class TestGitChangeListerForCommitted(private val testRepoPath: File) : IGitChan
     private fun getMergeBase(gitRootPath: String): String? {
         val currentBranch = exec("git", "rev-parse", "--abbrev-ref", "HEAD").trim()
 
-        val mainBranchNames = listOf("main", "master", "develop", "trunk", "dev")
+        val mainBranchNames = listOf("main", "master", "develop", "trunk", "dev", "development")
         if (mainBranchNames.any { it.equals(currentBranch, ignoreCase = true) }) {
             return exec("git", "rev-parse", "HEAD").trim()
         }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt
@@ -15,7 +15,7 @@ import git4idea.repo.GitRepositoryManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-private val MAIN_BRANCH_NAMES = listOf("main", "master", "develop", "trunk", "dev")
+private val MAIN_BRANCH_NAMES = listOf("main", "master", "develop", "trunk", "dev", "development")
 
 @Service(Service.Level.PROJECT)
 class Git4IdeaChangeLister(

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
@@ -28,7 +28,7 @@ class Git4IdeaGitService(val project: Project) : IGitService {
         fun getInstance(project: Project): Git4IdeaGitService = project.service<Git4IdeaGitService>()
 
         private val MAIN_BRANCH_NAMES =
-            listOf("main", "master", "develop", "trunk", "dev")
+            listOf("main", "master", "develop", "trunk", "dev", "development")
     }
 
     /**

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverAdapter.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverAdapter.kt
@@ -1,0 +1,50 @@
+package com.codescene.jetbrains.platform.git
+
+import com.codescene.jetbrains.core.contracts.IFileSystem
+import com.codescene.jetbrains.core.contracts.IGitChangeLister
+import com.codescene.jetbrains.core.contracts.IOpenFilesObserver
+import com.codescene.jetbrains.core.contracts.ISavedFilesTracker
+import com.codescene.jetbrains.core.git.FileEvent
+import com.codescene.jetbrains.core.git.GitChangeObserver
+import com.intellij.openapi.Disposable
+
+class GitChangeObserverAdapter(
+    gitChangeLister: IGitChangeLister,
+    savedFilesTracker: ISavedFilesTracker,
+    openFilesObserver: IOpenFilesObserver,
+    fileSystem: IFileSystem,
+    onFileDeleted: (String) -> Unit,
+    onFileChanged: suspend (String) -> Unit,
+    workspacePath: String,
+    gitRootPath: String,
+    batchIntervalMs: Long = 1000L,
+) : Disposable {
+    private val observer =
+        GitChangeObserver(
+            gitChangeLister,
+            savedFilesTracker,
+            openFilesObserver,
+            fileSystem,
+            onFileDeleted,
+            onFileChanged,
+            workspacePath,
+            gitRootPath,
+            batchIntervalMs,
+        )
+
+    fun start() = observer.start()
+
+    fun queueEvent(event: FileEvent) = observer.queueEvent(event)
+
+    suspend fun processQueuedEvents() = observer.processQueuedEvents()
+
+    suspend fun getChangedFilesVsBaseline(): Set<String> = observer.getChangedFilesVsBaseline()
+
+    fun removeFromTracker(filePath: String) = observer.removeFromTracker(filePath)
+
+    fun getTrackedFiles(): Set<String> = observer.getTrackedFiles()
+
+    fun getQueuedEventCount(): Int = observer.getQueuedEventCount()
+
+    override fun dispose() = observer.dispose()
+}


### PR DESCRIPTION
Ports it from VSC and to a lesser extent, VS.

`GitChangeObserverAdapter` is the usable class.

Not integrated into the extension yet.