### PR TITLE
fix: CS-6848: reduce code vision and highlight flicker during review

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/IAceRefactorableFunctionsCache.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/IAceRefactorableFunctionsCache.kt
@@ -8,6 +8,8 @@ interface IAceRefactorableFunctionsCache {
         content: String,
     ): List<FnToRefactor>
 
+    fun getLastKnown(filePath: String): List<FnToRefactor>
+
     fun put(
         filePath: String,
         content: String,

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/IReviewCacheService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/IReviewCacheService.kt
@@ -7,6 +7,8 @@ import com.codescene.jetbrains.core.review.ReviewCacheQuery
 interface IReviewCacheService {
     fun get(query: ReviewCacheQuery): Review?
 
+    fun getLastKnown(filePath: String): Review?
+
     fun put(entry: ReviewCacheEntry)
 
     fun invalidate(filePath: String)

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/review/AceRefactorableFunctionsCacheService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/review/AceRefactorableFunctionsCacheService.kt
@@ -42,6 +42,8 @@ open class AceRefactorableFunctionsCacheService(
         return emptyList()
     }
 
+    override fun getLastKnown(filePath: String): List<FnToRefactor> = cache[filePath]?.result.orEmpty()
+
     override fun put(entry: AceRefactorableFunctionCacheEntry) {
         val (filePath, content, result) = entry
         val code = DigestUtils.sha256Hex(content)

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/review/ReviewCacheService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/review/ReviewCacheService.kt
@@ -51,6 +51,8 @@ open class ReviewCacheService(
         return if (cacheHit) apiResponse else null
     }
 
+    fun getLastKnown(filePath: String): Review? = cache[filePath]?.response
+
     override fun put(entry: ReviewCacheEntry) {
         val (fileContents, filePath, response) = entry
 

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/AceRefactorableFunctionsCacheServiceTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/AceRefactorableFunctionsCacheServiceTest.kt
@@ -92,6 +92,37 @@ class AceRefactorableFunctionsCacheServiceTest {
     }
 
     @Test
+    fun `getLastKnown returns stored result even when content hash differs`() {
+        cache.put("a.kt", "content", listOf(createFn("fn1")))
+
+        assertTrue(cache.get("a.kt", "different content").isEmpty())
+        assertEquals(1, cache.getLastKnown("a.kt").size)
+        assertEquals("fn1", cache.getLastKnown("a.kt")[0].name)
+    }
+
+    @Test
+    fun `getLastKnown returns empty list when there is no entry`() {
+        assertTrue(cache.getLastKnown("a.kt").isEmpty())
+    }
+
+    @Test
+    fun `getLastKnown returns latest result after put is called again`() {
+        cache.put("a.kt", "v1", listOf(createFn("old")))
+        cache.put("a.kt", "v2", listOf(createFn("new")))
+
+        assertEquals("new", cache.getLastKnown("a.kt")[0].name)
+    }
+
+    @Test
+    fun `getLastKnown returns empty list after invalidate`() {
+        cache.put("a.kt", "content", listOf(createFn()))
+
+        cache.invalidate("a.kt")
+
+        assertTrue(cache.getLastKnown("a.kt").isEmpty())
+    }
+
+    @Test
     fun `query-based get works the same as convenience get`() {
         cache.put("a.kt", "content", listOf(createFn("fn1")))
         val query = AceRefactorableFunctionCacheQuery("a.kt", "content")

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/ReviewCacheServiceTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/ReviewCacheServiceTest.kt
@@ -96,6 +96,37 @@ class ReviewCacheServiceTest {
     }
 
     @Test
+    fun `getLastKnown returns stored response even when content hash differs`() {
+        reviewCacheService.put(ReviewCacheEntry(fileContents, filePath, response))
+
+        assertNull(reviewCacheService.get(ReviewCacheQuery(newFileContents, filePath)))
+        assertEquals(response, reviewCacheService.getLastKnown(filePath))
+    }
+
+    @Test
+    fun `getLastKnown returns null when there is no entry for the file`() {
+        assertNull(reviewCacheService.getLastKnown(filePath))
+    }
+
+    @Test
+    fun `getLastKnown returns latest response after put is called again`() {
+        val updated: Review = mockk()
+        reviewCacheService.put(ReviewCacheEntry(fileContents, filePath, response))
+        reviewCacheService.put(ReviewCacheEntry(newFileContents, filePath, updated))
+
+        assertEquals(updated, reviewCacheService.getLastKnown(filePath))
+    }
+
+    @Test
+    fun `getLastKnown returns null after invalidate`() {
+        reviewCacheService.put(ReviewCacheEntry(fileContents, filePath, response))
+
+        reviewCacheService.invalidate(filePath)
+
+        assertNull(reviewCacheService.getLastKnown(filePath))
+    }
+
+    @Test
     fun `updateKey does nothing if old key does not exist`() {
         val newFilePath = "/path/to/renamed_file.txt"
 

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/InMemoryAceRefactorableFunctionsCache.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/InMemoryAceRefactorableFunctionsCache.kt
@@ -16,6 +16,8 @@ class InMemoryAceRefactorableFunctionsCache : IAceRefactorableFunctionsCache {
         return cache[filePath]?.takeIf { it.contentHash == contentHash }?.result.orEmpty()
     }
 
+    override fun getLastKnown(filePath: String): List<FnToRefactor> = cache[filePath]?.result.orEmpty()
+
     override fun put(
         filePath: String,
         content: String,

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/InMemoryReviewCacheService.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/InMemoryReviewCacheService.kt
@@ -12,6 +12,8 @@ class InMemoryReviewCacheService : IReviewCacheService {
 
     override fun get(query: ReviewCacheQuery): Review? = delegate.get(query)
 
+    override fun getLastKnown(filePath: String): Review? = delegate.getLastKnown(filePath)
+
     override fun put(entry: ReviewCacheEntry) {
         delegate.put(entry)
     }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/CachedReviewService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/CachedReviewService.kt
@@ -99,7 +99,6 @@ class CachedReviewService(
         if (review == null) {
             val f = path.substringAfterLast('/')
             Log.debug("cached review no result file=$f len=${currentCode.length}", "CodeSceneCachedReview")
-            uiRefreshService.refreshCodeVision(path, CodeSceneCodeVisionProvider.getProviders())
             return
         }
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/editor/UIRefreshService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/editor/UIRefreshService.kt
@@ -4,7 +4,6 @@ import com.codescene.jetbrains.core.contracts.IUIRefreshService
 import com.codescene.jetbrains.platform.util.Log
 import com.intellij.codeInsight.codeVision.CodeVisionHost
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -84,11 +83,7 @@ class UIRefreshService(
 
             withContext(Dispatchers.Main) {
                 try {
-                    ApplicationManager
-                        .getApplication()
-                        .runWriteAction<Unit, RuntimeException> {
-                            restartDaemon(psiFile)
-                        }
+                    restartDaemon(psiFile)
                 } catch (e: Exception) {
                     Log.warn("Failed to refresh annotations for file: ${psiFile.name}. Error: ${e.message}")
                 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/editor/annotator/CodeSmellAnnotator.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/editor/annotator/CodeSmellAnnotator.kt
@@ -148,8 +148,15 @@ class CodeSmellAnnotator : ExternalAnnotator<
             fallback = null,
         ) {
             val path = psiFile.virtualFile.path
-            val query = ReviewCacheQuery(content, path)
-            CodeSceneProjectServiceProvider.getInstance(psiFile.project).reviewCacheService.get(query)
+            val reviewCacheService =
+                CodeSceneProjectServiceProvider.getInstance(psiFile.project).reviewCacheService
+            val fresh = reviewCacheService.get(ReviewCacheQuery(content, path))
+            if (fresh != null) {
+                return@runSafeAction fresh
+            }
+            reviewCacheService.getLastKnown(path)?.also {
+                Log.debug("annotator reusing stale review file=${psiFile.name}")
+            }
         }.also {
             if (it == null) {
                 Log.info("No cache available for ${resolvePathForLogging(psiFile)}. Skipping annotation.")

--- a/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/CodeSceneCodeVisionProvider.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/CodeSceneCodeVisionProvider.kt
@@ -149,10 +149,23 @@ abstract class CodeSceneCodeVisionProvider : CodeVisionProvider<Unit> {
         scheduleReviewIfNeeded(project, editor, decision, shortPath)
 
         return when (decision.action) {
-            CodeVisionAction.NOT_READY -> CodeVisionState.NotReady
+            CodeVisionAction.NOT_READY -> resolveNotReadyState(editor, serviceProvider, shortPath)
             CodeVisionAction.READY_EMPTY -> CodeVisionState.READY_EMPTY
             CodeVisionAction.READY -> CodeVisionState.Ready(getLenses(editor, cachedReview))
         }
+    }
+
+    private fun resolveNotReadyState(
+        editor: Editor,
+        serviceProvider: CodeSceneProjectServiceProvider,
+        shortPath: String,
+    ): CodeVisionState {
+        val filePath = editor.virtualFile.path
+        val staleReview =
+            serviceProvider.reviewCacheService.getLastKnown(filePath)
+                ?: return CodeVisionState.NotReady
+        Log.debug("code vision reusing stale lenses file=$shortPath", "CodeSceneCodeVision")
+        return CodeVisionState.Ready(getLenses(editor, staleReview))
     }
 
     open fun getLenses(

--- a/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/ReviewSmellCodeVisionGrouping.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/ReviewSmellCodeVisionGrouping.kt
@@ -14,10 +14,16 @@ internal fun collectSmellsWithHighlightRangesForVision(
     categories: List<String>,
 ): List<Pair<TextRange, CodeVisionCodeSmell>> {
     val out = ArrayList<Pair<TextRange, CodeVisionCodeSmell>>()
+    val document = editor.document
+    val lineCount = document.lineCount
     for (category in categories) {
         for (smell in getCodeSmellsByCategory(result, category)) {
-            val range =
-                getTextRange(smell.highlightRange.startLine to smell.highlightRange.endLine, editor.document)
+            val startLine = smell.highlightRange.startLine
+            val endLine = smell.highlightRange.endLine
+            if (startLine < 1 || endLine < startLine || endLine > lineCount) {
+                continue
+            }
+            val range = getTextRange(startLine to endLine, document)
             out.add(range to smell)
         }
     }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.vcsUtil.VcsUtil
 import git4idea.commands.Git
 import git4idea.commands.GitCommand
 import git4idea.repo.GitRepository
@@ -65,18 +66,7 @@ class Git4IdeaGitService(val project: Project) : IGitService {
 
     override fun isIgnored(filePath: String): Boolean {
         val context = getRepositoryContext(filePath) ?: return false
-        val handler =
-            createGitLineHandler(project, context.repository.root, GitCommand.LS_FILES).apply {
-                addParameters("--ignored", "--exclude-standard", "--others", "--", context.relativePath)
-            }
-        val result = Git.getInstance().runCommand(handler)
-
-        if (!result.success()) {
-            Log.warn("Could not determine ignore status for ${context.file.path}.", service)
-            return false
-        }
-
-        return result.output.any { it.trim().removeSurrounding("\"") == context.relativePath }
+        return context.repository.ignoredFilesHolder.containsFile(VcsUtil.getFilePath(context.file))
     }
 
     private fun isMainLineBranch(branchName: String): Boolean =

--- a/src/main/kotlin/com/codescene/jetbrains/platform/listeners/FileEditorLifecycleListener.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/listeners/FileEditorLifecycleListener.kt
@@ -1,23 +1,24 @@
 package com.codescene.jetbrains.platform.listeners
 
+import com.codescene.jetbrains.core.review.ReviewCacheQuery
 import com.codescene.jetbrains.core.review.cancelPendingReviews
 import com.codescene.jetbrains.core.util.TelemetryEvents
 import com.codescene.jetbrains.platform.UiLabelsBundle
 import com.codescene.jetbrains.platform.api.CachedReviewService
 import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
-import com.codescene.jetbrains.platform.editor.UIRefreshService
-import com.codescene.jetbrains.platform.editor.codeVision.CodeSceneCodeVisionProvider
 import com.codescene.jetbrains.platform.editor.codeVision.CodeVisionReviewScheduleHint
 import com.codescene.jetbrains.platform.util.Log
+import com.codescene.jetbrains.platform.util.isFileSupported
 import com.codescene.jetbrains.platform.webview.util.updateMonitor
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class FileEditorLifecycleListener : FileEditorManagerListener {
@@ -35,22 +36,7 @@ class FileEditorLifecycleListener : FileEditorManagerListener {
         }
         val file = event.newFile ?: return
         recordForegroundDocumentStamp(event.manager, file)
-        CoroutineScope(Dispatchers.Main).launch {
-            if (project.isDisposed) {
-                return@launch
-            }
-            val ui = UIRefreshService.getInstance(project)
-            val editors = event.manager.getEditors(file)
-            if (editors.isEmpty()) {
-                Log.debug("selectionChanged: no editors for file=${file.path}", "FileEditorLifecycle")
-                return@launch
-            }
-            for (fileEditor in editors) {
-                val editor = (fileEditor as? TextEditor)?.editor ?: continue
-                ui.refreshCodeVision(editor, CodeSceneCodeVisionProvider.getProviders())
-            }
-            Log.debug("selectionChanged: refreshed code vision for file=${file.name}", "FileEditorLifecycle")
-        }
+        ensureInitialReview(project, event.manager, file)
     }
 
     override fun fileClosed(
@@ -79,13 +65,40 @@ class FileEditorLifecycleListener : FileEditorManagerListener {
         manager: FileEditorManager,
         file: VirtualFile,
     ) {
-        val editor =
-            manager.getEditors(file).firstNotNullOfOrNull { fe ->
-                (fe as? TextEditor)?.editor
-            } ?: return
+        val editor = getTextEditor(manager, file) ?: return
         CodeVisionReviewScheduleHint.recordDocumentStampWhenFileForegrounded(
             file.path,
             editor.document.modificationStamp,
         )
     }
+
+    private fun ensureInitialReview(
+        project: Project,
+        manager: FileEditorManager,
+        file: VirtualFile,
+    ) {
+        if (project.isDisposed) return
+        val editor = getTextEditor(manager, file) ?: return
+        val reviewService = project.service<CachedReviewService>()
+        if (reviewService.activeReviewCalls.contains(file.path)) return
+        reviewService.scope.launch {
+            if (project.isDisposed) return@launch
+            val supported = ReadAction.compute<Boolean, RuntimeException> { isFileSupported(project, file) }
+            if (!supported) return@launch
+            val text = ReadAction.compute<String, RuntimeException> { editor.document.text }
+            val services = CodeSceneProjectServiceProvider.getInstance(project)
+            if (services.reviewCacheService.get(ReviewCacheQuery(text, file.path)) != null) return@launch
+            if (reviewService.activeReviewCalls.contains(file.path)) return@launch
+            Log.debug("ensuring initial review file=${file.name}", "FileEditorLifecycle")
+            reviewService.review(editor)
+        }
+    }
+
+    private fun getTextEditor(
+        manager: FileEditorManager,
+        file: VirtualFile,
+    ): Editor? =
+        manager.getEditors(file).firstNotNullOfOrNull { fe ->
+            (fe as? TextEditor)?.editor
+        }
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
@@ -124,11 +124,12 @@ class AceEntryOrchestrator(private val project: Project) {
         path: String,
         content: String,
     ): List<FnToRefactor> {
-        val query = AceRefactorableFunctionCacheQuery(path, content)
-
-        return PlatformAceRefactorableFunctionsCacheService.getInstance(project).get(query).also {
-            if (it.isEmpty()) Log.debug("No ACE refactorable functions cache available for $path. Skipping annotation.")
-        }
+        val cacheService = PlatformAceRefactorableFunctionsCacheService.getInstance(project)
+        val fresh = cacheService.get(AceRefactorableFunctionCacheQuery(path, content))
+        if (fresh.isNotEmpty()) return fresh
+        val stale = cacheService.getLastKnown(path)
+        Log.debug("ACE refactorable functions cache ${if (stale.isEmpty()) "miss" else "stale"} for $path.")
+        return stale
     }
 
     suspend fun checkContainsRefactorableFunctions(

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/WebViewFactory.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/WebViewFactory.kt
@@ -14,6 +14,10 @@ import javax.swing.JLabel
 import org.cef.browser.CefMessageRouter
 
 object WebViewFactory {
+    init {
+        System.setProperty("ide.browser.jcef.out-of-process.enabled", "false")
+    }
+
     /**
      * Creates a generic JCEF WebView component for a given project, view type, and optional initial data.
      * This encapsulates:


### PR DESCRIPTION
## Summary

- Fall back to the last-known cached review/ACE results on a content-hash miss so Code Vision lenses and code smell highlights persist while a new review runs, eliminating flicker on edits.
- Remove redundant Code Vision refreshes on tab switch and when no fresh review result is available to reduce the performance regression from the previous fix.
- Trigger the initial review from `selectionChanged` so the active document is reviewed on IDE startup without reviewing every restored background tab.

## Test plan

- [ ] Open IntelliJ with a previously open active document and confirm it gets reviewed automatically (Code Vision + highlights appear).
- [ ] Confirm background (non-selected) tabs are NOT reviewed until switched to.
- [ ] Edit an active document with existing highlights/Code Vision and confirm they remain visible (no flicker) while the review re-runs, then refresh on completion.
- [ ] Switch between already-reviewed tabs and confirm no unnecessary refresh/flicker.
- [ ] Validate both on IntelliJ 2023.3.8 and 2025.1.4.1.
