### PR TITLE
Fix Windows path handling for delta reviews

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/delta/DeltaCacheService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/delta/DeltaCacheService.kt
@@ -2,6 +2,8 @@ package com.codescene.jetbrains.core.delta
 
 import com.codescene.data.delta.Delta
 import com.codescene.jetbrains.core.contracts.ILogger
+import com.codescene.jetbrains.core.git.pathCacheKey
+import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.core.review.CacheService
 import org.apache.commons.codec.digest.DigestUtils
 
@@ -10,6 +12,7 @@ data class DeltaCacheItem(
     val currentHash: String,
     val deltaApiResponse: Delta?,
     val includeInCodeHealthMonitor: Boolean = true,
+    val filePath: String = "",
 )
 
 data class DeltaCacheEntry(
@@ -49,19 +52,20 @@ open class DeltaCacheService(
         val oldHash = DigestUtils.sha256Hex(headCommitContent)
         val newHash = DigestUtils.sha256Hex(currentFileContent)
 
-        val entry = cache[filePath]
+        val cacheKey = key(filePath)
+        val entry = cache[cacheKey]
         val apiResponse = entry?.deltaApiResponse
 
         val headMatches = entry?.headHash == oldHash
         val currentMatches = entry?.currentHash == newHash
         val contentsMatch = headMatches && currentMatches
-        val isCacheHitOrNotStale = cache.containsKey(filePath) && contentsMatch
+        val isCacheHitOrNotStale = cache.containsKey(cacheKey) && contentsMatch
 
         if (!isCacheHitOrNotStale) {
-            val shortPath = filePath.substringAfterLast('/')
+            val shortPath = pathFileName(filePath)
             val reason =
                 when {
-                    !cache.containsKey(filePath) -> "no_entry"
+                    !cache.containsKey(cacheKey) -> "no_entry"
                     !headMatches && !currentMatches -> "head_and_current_mismatch"
                     !headMatches -> "head_mismatch"
                     else -> "current_mismatch"
@@ -82,14 +86,15 @@ open class DeltaCacheService(
         val headHash = DigestUtils.sha256Hex(entry.headContent)
         val currentContentHash = DigestUtils.sha256Hex(entry.currentFileContent)
 
-        cache[entry.filePath] =
+        cache[key(entry.filePath)] =
             DeltaCacheItem(
                 headHash,
                 currentContentHash,
                 entry.deltaApiResponse,
                 entry.includeInCodeHealthMonitor,
+                entry.filePath,
             )
-        val shortPath = entry.filePath.substringAfterLast('/')
+        val shortPath = pathFileName(entry.filePath)
         log.debug(
             "delta cache put file=$shortPath head=${headHash.take(8)} cur=${currentContentHash.take(8)} " +
                 "lenBaseline=${entry.headContent.length} lenCurrent=${entry.currentFileContent.length} " +
@@ -102,13 +107,14 @@ open class DeltaCacheService(
         filePath: String,
         include: Boolean,
     ) {
-        val existing = cache[filePath] ?: return
-        cache[filePath] = existing.copy(includeInCodeHealthMonitor = include)
+        val cacheKey = key(filePath)
+        val existing = cache[cacheKey] ?: return
+        cache[cacheKey] = existing.copy(includeInCodeHealthMonitor = include)
     }
 
     override fun getAll(): List<Pair<String, DeltaCacheItem>> {
         return cache.entries
-            .map { it.key to it.value }
+            .map { (key, item) -> (item.filePath.ifEmpty { key }) to item }
             .filter { (_, item) ->
                 if (!item.includeInCodeHealthMonitor) return@filter false
                 val delta = item.deltaApiResponse ?: return@filter false
@@ -117,4 +123,6 @@ open class DeltaCacheService(
                 scoreChanged || codeChanged
             }
     }
+
+    override fun key(filePath: String): String = pathCacheKey(filePath)
 }

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitChangeObserver.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitChangeObserver.kt
@@ -58,7 +58,7 @@ class GitChangeObserver(
     }
 
     fun queueEvent(event: FileEvent) {
-        logger.info("Queued event type=${event.type} path=${event.path.substringAfterLast('/')}", "GitChangeObserver")
+        logger.info("Queued event type=${event.type} path=${pathFileName(event.path)}", "GitChangeObserver")
         synchronized(eventQueue) {
             eventQueue.add(event)
         }
@@ -78,7 +78,7 @@ class GitChangeObserver(
 
         val deduplicatedEvents =
             events
-                .groupBy { it.path }
+                .groupBy { comparisonKey(it.path) }
                 .mapValues { it.value.last() }
                 .values
                 .toList()
@@ -104,8 +104,9 @@ class GitChangeObserver(
     }
 
     fun removeFromTracker(filePath: String) {
+        val key = comparisonKey(filePath)
         synchronized(tracker) {
-            tracker.remove(filePath)
+            tracker.removeIf { comparisonKey(it) == key }
         }
     }
 
@@ -141,7 +142,8 @@ class GitChangeObserver(
         filePath: String,
         changedFiles: Set<String>,
     ): Boolean {
-        return changedFiles.contains(filePath)
+        val key = comparisonKey(filePath)
+        return changedFiles.any { comparisonKey(it) == key }
     }
 
     private suspend fun handleFileCreate(filePath: String) {
@@ -160,9 +162,7 @@ class GitChangeObserver(
             return
         }
 
-        synchronized(tracker) {
-            tracker.add(filePath)
-        }
+        addToTracker(filePath)
         logger.info("Added created file to tracker", "GitChangeObserver")
         onFileChanged(filePath)
     }
@@ -182,9 +182,7 @@ class GitChangeObserver(
             return
         }
 
-        synchronized(tracker) {
-            tracker.add(filePath)
-        }
+        addToTracker(filePath)
         logger.info("Added file to tracker", "GitChangeObserver")
         onFileChanged(filePath)
     }
@@ -193,11 +191,13 @@ class GitChangeObserver(
         filePath: String,
         changedFiles: Set<String>,
     ) {
+        val key = comparisonKey(filePath)
         synchronized(tracker) {
-            if (tracker.contains(filePath)) {
-                tracker.remove(filePath)
+            val trackedFile = tracker.firstOrNull { comparisonKey(it) == key }
+            if (trackedFile != null) {
+                tracker.remove(trackedFile)
                 logger.info("Removing tracked file", "GitChangeObserver")
-                onFileDeleted(filePath)
+                onFileDeleted(trackedFile)
                 return
             }
         }
@@ -211,12 +211,12 @@ class GitChangeObserver(
         val isDirectory = extension.isEmpty()
 
         if (isDirectory) {
-            val normalizedDirPath = filePath.replace('\\', '/')
+            val normalizedDirPath = pathComparisonKey(filePath)
             val directoryPrefix =
                 if (normalizedDirPath.endsWith("/")) normalizedDirPath else normalizedDirPath + "/"
             val filesToDelete: List<String>
             synchronized(tracker) {
-                filesToDelete = tracker.filter { it.replace('\\', '/').startsWith(directoryPrefix) }
+                filesToDelete = tracker.filter { pathComparisonKey(it).startsWith(directoryPrefix) }
             }
 
             logger.info("Directory deletion cascade files=${filesToDelete.size}", "GitChangeObserver")
@@ -229,4 +229,14 @@ class GitChangeObserver(
             }
         }
     }
+
+    private fun addToTracker(filePath: String) {
+        val key = comparisonKey(filePath)
+        synchronized(tracker) {
+            tracker.removeIf { comparisonKey(it) == key }
+            tracker.add(filePath)
+        }
+    }
+
+    private fun comparisonKey(filePath: String): String = gitRelativeComparisonKey(gitRootPath, filePath)
 }

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitPathUtils.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitPathUtils.kt
@@ -3,6 +3,40 @@ package com.codescene.jetbrains.core.git
 import java.io.File
 import java.nio.file.Paths
 
+private fun hasWindowsDriveLetter(path: String): Boolean = path.length >= 3 && path[1] == ':' && path[2] == '/'
+
+fun pathComparisonKey(path: String): String {
+    val normalized = path.replace('\\', '/')
+    return if (hasWindowsDriveLetter(normalized)) normalized.lowercase() else normalized
+}
+
+fun gitRelativeComparisonKey(
+    gitRootPath: String,
+    filePath: String,
+): String {
+    val root = pathComparisonKey(gitRootPath).trimEnd('/')
+    val file = pathComparisonKey(filePath)
+    val prefix = "$root/"
+    return when {
+        file == root -> ""
+        file.startsWith(prefix) -> file.removePrefix(prefix)
+        else -> file
+    }
+}
+
+fun pathCacheKey(path: String): String = pathComparisonKey(path)
+
+fun pathFileName(path: String): String = path.replace('\\', '/').substringAfterLast('/')
+
+fun isPathUnderRoot(
+    path: String,
+    rootPath: String,
+): Boolean {
+    val root = pathComparisonKey(rootPath).trimEnd('/')
+    val file = pathComparisonKey(path)
+    return file == root || file.startsWith("$root/")
+}
+
 data class WorkspacePrefix(
     val normalizedWorkspacePath: String,
     val workspacePrefix: String,

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/mapper/CodeHealthMonitorMapper.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/mapper/CodeHealthMonitorMapper.kt
@@ -1,6 +1,7 @@
 package com.codescene.jetbrains.core.mapper
 
 import com.codescene.jetbrains.core.delta.DeltaCacheItem
+import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.core.models.CwfData
 import com.codescene.jetbrains.core.models.View
 import com.codescene.jetbrains.core.models.shared.AnalysisJob
@@ -96,7 +97,7 @@ class CodeHealthMonitorMapper {
             AnalysisJob(
                 type = DELTA_ANALYSIS_JOB,
                 state = JOB_STATE_RUNNING,
-                file = FileMetaType(fileName = job),
+                file = FileMetaType(fileName = pathFileName(job)),
             )
         }
 

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/review/BaselineReviewCacheService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/review/BaselineReviewCacheService.kt
@@ -2,6 +2,7 @@ package com.codescene.jetbrains.core.review
 
 import com.codescene.jetbrains.core.contracts.IBaselineReviewCacheService
 import com.codescene.jetbrains.core.contracts.ILogger
+import com.codescene.jetbrains.core.git.pathCacheKey
 
 data class BaselineReviewCacheItem(
     val fileContents: String,
@@ -31,13 +32,16 @@ open class BaselineReviewCacheService(
     override fun get(query: BaselineReviewCacheQuery): Pair<Boolean, Double?> {
         val (fileContents, filePath) = query
         val hash = hash(fileContents)
-        val entry = cache[filePath]
-        val cacheHit = cache.containsKey(filePath) && entry?.fileContents == hash
+        val cacheKey = key(filePath)
+        val entry = cache[cacheKey]
+        val cacheHit = cache.containsKey(cacheKey) && entry?.fileContents == hash
         return cacheHit to entry?.score
     }
 
     override fun put(entry: BaselineReviewCacheEntry) {
         val (fileContents, filePath, score) = entry
-        cache[filePath] = BaselineReviewCacheItem(hash(fileContents), score)
+        cache[key(filePath)] = BaselineReviewCacheItem(hash(fileContents), score)
     }
+
+    override fun key(filePath: String): String = pathCacheKey(filePath)
 }

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/review/CacheService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/review/CacheService.kt
@@ -19,9 +19,10 @@ abstract class CacheService<Q, E, V, R>(
     abstract fun put(entry: E)
 
     open fun invalidate(filePath: String) {
-        cache[filePath]?.let {
-            cache.remove(filePath)
-            log.debug("[$cacheImplementation] entry for key $filePath has been invalidated.")
+        val key = key(filePath)
+        cache[key]?.let {
+            cache.remove(key)
+            log.debug("[$cacheImplementation] entry for key $key has been invalidated.")
         }
     }
 
@@ -29,15 +30,19 @@ abstract class CacheService<Q, E, V, R>(
         oldFilePath: String,
         newFilePath: String,
     ) {
-        val entry = cache[oldFilePath]
+        val oldKey = key(oldFilePath)
+        val newKey = key(newFilePath)
+        val entry = cache[oldKey]
 
         if (entry != null) {
-            cache[newFilePath] = entry
+            cache[newKey] = entry
 
             invalidate(oldFilePath)
-            log.debug("[$cacheImplementation] $oldFilePath to $newFilePath.")
+            log.debug("[$cacheImplementation] $oldKey to $newKey.")
         }
     }
 
     open fun getAll(): List<Pair<String, V>> = cache.entries.map { it.key to it.value }
+
+    protected open fun key(filePath: String): String = filePath
 }

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/review/CodeReviewer.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/review/CodeReviewer.kt
@@ -1,6 +1,8 @@
 package com.codescene.jetbrains.core.review
 
 import com.codescene.jetbrains.core.contracts.ILogger
+import com.codescene.jetbrains.core.git.pathCacheKey
+import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.core.models.FailureType
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -20,7 +22,7 @@ class CodeReviewer(
     private val logger: ILogger,
     private val defaultDebounceDelayMs: Long = TimeUnit.SECONDS.toMillis(3),
 ) {
-    private val activeCalls = ConcurrentHashMap<String, Job>()
+    private val activeCalls = ConcurrentHashMap<String, ActiveReviewCall>()
 
     fun reviewFile(
         filePath: String,
@@ -33,12 +35,13 @@ class CodeReviewer(
         onFinished: (() -> Unit)? = null,
     ) {
         val delayBeforeRun = debounceDelayMs ?: defaultDebounceDelayMs
-        val shortPath = filePath.substringAfterLast('/')
+        val callKey = pathCacheKey(filePath)
+        val shortPath = pathFileName(filePath)
 
-        val existingJob = activeCalls[filePath]
+        val existingJob = activeCalls[callKey]
         if (existingJob != null) {
             logger.info("Cancelling existing job file=$shortPath", LOG_TAG)
-            existingJob.cancel()
+            existingJob.job.cancel()
         }
 
         lateinit var job: Job
@@ -59,7 +62,7 @@ class CodeReviewer(
                 } catch (e: Exception) {
                     onError(FailureType.FAILED, e.message)
                 } finally {
-                    val removed = activeCalls.remove(filePath, job)
+                    val removed = activeCalls.remove(callKey, ActiveReviewCall(filePath, job))
                     if (removed) {
                         logger.info("Job removed file=$shortPath active=${activeCalls.size}", LOG_TAG)
                         onFinished?.invoke()
@@ -70,21 +73,26 @@ class CodeReviewer(
             }
 
         logger.info("Job added file=$shortPath active=${activeCalls.size + 1}", LOG_TAG)
-        activeCalls[filePath] = job
+        activeCalls[callKey] = ActiveReviewCall(filePath, job)
         onScheduled?.invoke()
         job.start()
     }
 
     fun cancel(filePath: String): Boolean {
-        val job = activeCalls.remove(filePath) ?: return false
-        job.cancel()
+        val job = activeCalls.remove(pathCacheKey(filePath)) ?: return false
+        job.job.cancel()
         return true
     }
 
-    fun activeFilePaths(): Set<String> = activeCalls.keys
+    fun activeFilePaths(): Set<String> = activeCalls.values.mapTo(mutableSetOf()) { it.filePath }
 
     fun dispose() {
-        activeCalls.values.forEach { it.cancel() }
+        activeCalls.values.forEach { it.job.cancel() }
         activeCalls.clear()
     }
 }
+
+private data class ActiveReviewCall(
+    val filePath: String,
+    val job: Job,
+)

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/review/ReviewCacheService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/review/ReviewCacheService.kt
@@ -2,6 +2,8 @@ package com.codescene.jetbrains.core.review
 
 import com.codescene.data.review.Review
 import com.codescene.jetbrains.core.contracts.ILogger
+import com.codescene.jetbrains.core.git.pathCacheKey
+import com.codescene.jetbrains.core.git.pathFileName
 import org.apache.commons.codec.digest.DigestUtils
 
 data class ReviewCacheItem(
@@ -29,16 +31,17 @@ open class ReviewCacheService(
         val (fileContents, filePath) = query
 
         val hash = DigestUtils.sha256Hex(fileContents)
+        val cacheKey = key(filePath)
 
-        val apiResponse = cache[filePath]?.response
-        val storedHash = cache[filePath]?.fileContents
-        val cacheHit = cache.containsKey(filePath) && storedHash == hash
+        val apiResponse = cache[cacheKey]?.response
+        val storedHash = cache[cacheKey]?.fileContents
+        val cacheHit = cache.containsKey(cacheKey) && storedHash == hash
 
         if (!cacheHit) {
-            val shortPath = filePath.substringAfterLast('/')
+            val shortPath = pathFileName(filePath)
             val reason =
                 when {
-                    !cache.containsKey(filePath) -> "no_entry"
+                    !cache.containsKey(cacheKey) -> "no_entry"
                     else -> "content_hash_mismatch"
                 }
             log.debug(
@@ -51,13 +54,15 @@ open class ReviewCacheService(
         return if (cacheHit) apiResponse else null
     }
 
-    fun getLastKnown(filePath: String): Review? = cache[filePath]?.response
+    fun getLastKnown(filePath: String): Review? = cache[key(filePath)]?.response
 
     override fun put(entry: ReviewCacheEntry) {
         val (fileContents, filePath, response) = entry
 
         val contentHash = DigestUtils.sha256Hex(fileContents)
 
-        cache[filePath] = ReviewCacheItem(contentHash, response)
+        cache[key(filePath)] = ReviewCacheItem(contentHash, response)
     }
+
+    override fun key(filePath: String): String = pathCacheKey(filePath)
 }

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/delta/DeltaCacheServiceTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/delta/DeltaCacheServiceTest.kt
@@ -142,4 +142,39 @@ class DeltaCacheServiceTest {
 
         assertEquals(0, deltaCacheService.getAll().size)
     }
+
+    @Test
+    fun `setIncludeInCodeHealthMonitor restores visible cache entry`() {
+        val delta = mockk<Delta>()
+        every { delta.scoreChange } returns 1.0
+        deltaCacheService.put(DeltaCacheEntry(filePath, headCommitContent, currentFileContent, delta))
+
+        deltaCacheService.setIncludeInCodeHealthMonitor(filePath, false)
+        deltaCacheService.setIncludeInCodeHealthMonitor(filePath, true)
+
+        assertEquals(1, deltaCacheService.getAll().size)
+    }
+
+    @Test
+    fun `cache operations match Windows paths across separator differences`() {
+        val delta = mockk<Delta>()
+        every { delta.scoreChange } returns 1.0
+        val backslashPath = "C:\\repo\\src\\file.kt"
+        val slashPath = "C:/repo/src/file.kt"
+        deltaCacheService.put(DeltaCacheEntry(backslashPath, headCommitContent, currentFileContent, delta))
+
+        val cachedResponse =
+            deltaCacheService.get(DeltaCacheQuery(slashPath, headCommitContent, currentFileContent))
+
+        assertEquals(true, cachedResponse.first)
+        assertEquals(delta, cachedResponse.second)
+
+        deltaCacheService.setIncludeInCodeHealthMonitor(slashPath, false)
+        assertEquals(0, deltaCacheService.getAll().size)
+
+        deltaCacheService.setIncludeInCodeHealthMonitor(slashPath, true)
+        val all = deltaCacheService.getAll()
+        assertEquals(1, all.size)
+        assertEquals(backslashPath, all[0].first)
+    }
 }

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverTest.kt
@@ -220,6 +220,32 @@ class GitChangeObserverTest {
         }
 
     @Test
+    fun `change event matches git changed file with Windows separator differences`() =
+        runBlocking {
+            val windowsObserver =
+                GitChangeObserver(
+                    gitChangeLister = mockGitChangeLister,
+                    savedFilesTracker = mockSavedFilesTracker,
+                    openFilesObserver = mockOpenFilesObserver,
+                    fileSystem = mockFileSystem,
+                    gitService = mockGitService,
+                    onFileDeleted = { deletedFiles.add(it) },
+                    onFileChanged = { changedFiles.add(it) },
+                    workspacePath = "C:/repo",
+                    gitRootPath = "C:/repo",
+                    logger = logger,
+                )
+
+            mockGitChangeLister.changedFiles = setOf("C:\\repo\\src\\file.ts")
+            windowsObserver.queueEvent(FileEvent(FileEventType.CHANGE, "C:/repo/src/file.ts"))
+            windowsObserver.queueEvent(FileEvent(FileEventType.CHANGE, "C:\\repo\\src\\file.ts"))
+            windowsObserver.processQueuedEvents()
+
+            assertEquals(1, changedFiles.size)
+            assertEquals(setOf("C:\\repo\\src\\file.ts"), windowsObserver.getTrackedFiles())
+        }
+
+    @Test
     fun `CREATE event tracks file without requiring git4idea confirmation`() =
         runBlocking {
             mockGitChangeLister.changedFiles = emptySet()

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/mapper/CodeHealthMonitorMapperTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/mapper/CodeHealthMonitorMapperTest.kt
@@ -213,7 +213,7 @@ class CodeHealthMonitorMapperTest {
         val parsed = Json.decodeFromString(CwfMessage.serializer(), result)
         assertEquals("update-renderer", parsed.messageType)
         assertTrue(result.contains("\"view\": \"home\""))
-        assertTrue(result.contains("\"src/Main.kt\""))
+        assertTrue(result.contains("\"Main.kt\""))
     }
 
     @Test
@@ -229,7 +229,7 @@ class CodeHealthMonitorMapperTest {
             )
 
         assertTrue(result.message.contains("\"view\": \"home\""))
-        assertTrue(result.message.contains("\"src/Main.kt\""))
+        assertTrue(result.message.contains("\"Main.kt\""))
         assertEquals(true, result.hasNotification)
     }
 

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/BaselineReviewCacheServiceTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/BaselineReviewCacheServiceTest.kt
@@ -47,6 +47,18 @@ class BaselineReviewCacheServiceTest {
     }
 
     @Test
+    fun `cache matches Windows paths across separator differences`() {
+        val backslashPath = "C:\\repo\\src\\File.kt"
+        val slashPath = "C:/repo/src/File.kt"
+        cache.put(BaselineReviewCacheEntry(fileContents, backslashPath, 8.5))
+
+        val (found, score) = cache.get(BaselineReviewCacheQuery(fileContents, slashPath))
+
+        assertTrue(found)
+        assertEquals(8.5, score)
+    }
+
+    @Test
     fun `cache can store null score as hit`() {
         cache.put(BaselineReviewCacheEntry(fileContents, filePath, null))
 

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/CodeReviewerTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/CodeReviewerTest.kt
@@ -84,6 +84,43 @@ class CodeReviewerTest {
     }
 
     @Test
+    fun `reviewFile cancels previous scheduled call for same Windows path with different separators`() {
+        val reviewer = CodeReviewer(CoroutineScope(Dispatchers.Default), TestLogger, defaultDebounceDelayMs = 200)
+        val firstExecuted = AtomicBoolean(false)
+        val secondExecuted = CountDownLatch(1)
+        val firstError = AtomicReference<FailureType?>()
+        val firstErrorObserved = CountDownLatch(1)
+
+        reviewer.reviewFile(
+            filePath = "C:\\repo\\src\\File.kt",
+            timeout = 2000,
+            runWithProgress = { action -> action() },
+            performAction = {
+                firstExecuted.set(true)
+            },
+            onError = { type, _ ->
+                firstError.set(type)
+                firstErrorObserved.countDown()
+            },
+        )
+
+        reviewer.reviewFile(
+            filePath = "C:/repo/src/File.kt",
+            timeout = 2000,
+            runWithProgress = { action -> action() },
+            performAction = {
+                secondExecuted.countDown()
+            },
+            onError = { _, _ -> },
+        )
+
+        assertTrue(secondExecuted.await(2, TimeUnit.SECONDS))
+        assertTrue(firstErrorObserved.await(2, TimeUnit.SECONDS))
+        assertEquals(false, firstExecuted.get())
+        assertEquals(FailureType.CANCELLED, firstError.get())
+    }
+
+    @Test
     fun `reviewFile executes action and invokes lifecycle callbacks`() {
         val reviewer = CodeReviewer(CoroutineScope(Dispatchers.Default), TestLogger, defaultDebounceDelayMs = 10)
         val scheduled = AtomicBoolean(false)

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/ReviewCacheServiceTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/ReviewCacheServiceTest.kt
@@ -60,6 +60,18 @@ class ReviewCacheServiceTest {
     }
 
     @Test
+    fun `cache matches Windows paths across separator differences`() {
+        val backslashPath = "C:\\repo\\src\\File.kt"
+        val slashPath = "C:/repo/src/File.kt"
+        reviewCacheService.put(ReviewCacheEntry(fileContents, backslashPath, response))
+
+        val cachedResponse = reviewCacheService.get(ReviewCacheQuery(fileContents, slashPath))
+
+        assertEquals(response, cachedResponse)
+        assertEquals(response, reviewCacheService.getLastKnown(slashPath))
+    }
+
+    @Test
     fun `invalidate removes cache entry and get returns null`() {
         val entry = ReviewCacheEntry(fileContents, filePath, response)
         reviewCacheService.put(entry)

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/CachedReviewService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/CachedReviewService.kt
@@ -4,6 +4,7 @@ import com.codescene.ExtensionAPI.CacheParams
 import com.codescene.ExtensionAPI.CodeParams
 import com.codescene.jetbrains.core.delta.DeltaCacheEntry
 import com.codescene.jetbrains.core.delta.DeltaCacheQuery
+import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.core.review.BaselineReviewCacheEntry
 import com.codescene.jetbrains.core.review.BaselineReviewCacheQuery
 import com.codescene.jetbrains.core.review.CodeReviewer
@@ -71,7 +72,7 @@ class CachedReviewService(
     }
 
     fun reviewByPath(filePath: String) {
-        val fileName = filePath.substringAfterLast('/')
+        val fileName = pathFileName(filePath)
         val serviceName = "$serviceImplementation - ${project.name}"
 
         reviewOrchestrator.reviewFile(
@@ -115,12 +116,12 @@ class CachedReviewService(
             review = reviewService.performCodeReview(editor)
         }
         if (review == null) {
-            val f = path.substringAfterLast('/')
+            val f = pathFileName(path)
             Log.debug("cached review no result file=$f len=${currentCode.length}", "CodeSceneCachedReview")
             return
         }
 
-        val f = path.substringAfterLast('/')
+        val f = pathFileName(path)
         Log.debug("cached review file=$f reviewMiss=$reviewMiss len=${currentCode.length}", "CodeSceneCachedReview")
 
         val aceUpdated =
@@ -169,16 +170,16 @@ class CachedReviewService(
             val query = DeltaCacheQuery(path, baselineCode, currentCode)
             val (deltaHit, _) = serviceProvider.deltaCacheService.get(query)
             if (deltaHit) {
-                val df = path.substringAfterLast('/')
+                val df = pathFileName(path)
                 Log.debug(
                     "handleDelta hit skip file=$df baseLen=${baselineCode.length}",
                     "CodeSceneCachedReview",
                 )
-                serviceProvider.deltaCacheService.setIncludeInCodeHealthMonitor(path, false)
+                serviceProvider.deltaCacheService.setIncludeInCodeHealthMonitor(path, true)
                 updateMonitor(project)
                 return DeltaHandlingResult(didHandleDelta = false)
             }
-            val df = path.substringAfterLast('/')
+            val df = pathFileName(path)
             Log.debug(
                 "handleDelta miss cachedReview file=$df baseLen=${baselineCode.length}",
                 "CodeSceneCachedReview",
@@ -187,7 +188,7 @@ class CachedReviewService(
 
         val deltaResult = deltaService.performDeltaAnalysis(editor)
         serviceProvider.deltaCacheService.setIncludeInCodeHealthMonitor(path, reviewMiss)
-        val df2 = path.substringAfterLast('/')
+        val df2 = pathFileName(path)
         Log.debug(
             "handleDelta done file=$df2 reviewMiss=$reviewMiss " +
                 "deltaNull=${deltaResult.delta == null}",

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/PathBasedReviewHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/PathBasedReviewHandler.kt
@@ -148,7 +148,7 @@ class PathBasedReviewHandler(private val project: Project) {
                 "handleDeltaByPath cache hit file=$fileName totalTime=${System.currentTimeMillis() - startTime}ms",
                 "CodeSceneCachedReview",
             )
-            serviceProvider.deltaCacheService.setIncludeInCodeHealthMonitor(filePath, false)
+            serviceProvider.deltaCacheService.setIncludeInCodeHealthMonitor(filePath, true)
             updateMonitor(project)
             return
         }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/delta/PlatformDeltaCacheService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/delta/PlatformDeltaCacheService.kt
@@ -3,6 +3,7 @@ package com.codescene.jetbrains.platform.delta
 import com.codescene.jetbrains.core.contracts.IDeltaCacheService
 import com.codescene.jetbrains.core.delta.DeltaCacheEntry
 import com.codescene.jetbrains.core.delta.DeltaCacheService
+import com.codescene.jetbrains.core.git.pathCacheKey
 import com.codescene.jetbrains.core.telemetry.monitorMetricsForDelta
 import com.codescene.jetbrains.core.telemetry.visibleInCodeHealthMonitor
 import com.codescene.jetbrains.core.util.TelemetryEvents
@@ -24,7 +25,7 @@ class PlatformDeltaCacheService(
     }
 
     override fun put(entry: DeltaCacheEntry) {
-        val path = entry.filePath
+        val path = pathCacheKey(entry.filePath)
         val previous = cache[path]
         val wasVisible = previous?.visibleInCodeHealthMonitor() == true
         super.put(entry)
@@ -52,7 +53,7 @@ class PlatformDeltaCacheService(
     }
 
     override fun invalidate(filePath: String) {
-        val previous = cache[filePath]
+        val previous = cache[pathCacheKey(filePath)]
         val wasVisible = previous?.visibleInCodeHealthMonitor() == true
         super.invalidate(filePath)
         updateMonitor(project)

--- a/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/CodeSceneCodeVisionProvider.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/CodeSceneCodeVisionProvider.kt
@@ -137,7 +137,7 @@ abstract class CodeSceneCodeVisionProvider : CodeVisionProvider<Unit> {
                 ),
             )
 
-        val shortPath = editor.virtualFile.path.substringAfterLast('/')
+        val shortPath = com.codescene.jetbrains.core.git.pathFileName(editor.virtualFile.path)
         Log.debug(
             "code vision file=$shortPath hasReview=${cachedReview != null} hasDelta=${cachedDelta.first} " +
                 "monitor=${settings.codeHealthMonitorEnabled} needsReview=${decision.needsReviewApiCall} " +

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt
@@ -5,6 +5,8 @@ import com.codescene.jetbrains.core.contracts.IGitChangeLister
 import com.codescene.jetbrains.core.git.FileSystemAdapter
 import com.codescene.jetbrains.core.git.MAX_UNTRACKED_FILES_PER_LOCATION
 import com.codescene.jetbrains.core.git.createWorkspacePrefix
+import com.codescene.jetbrains.core.git.pathComparisonKey
+import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.platform.util.Log
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -18,11 +20,15 @@ import kotlinx.coroutines.withContext
 
 private val MAIN_BRANCH_NAMES = listOf("main", "master", "develop", "trunk", "dev", "development")
 
-private fun hasWindowsDriveLetter(path: String): Boolean = path.length >= 3 && path[1] == ':' && path[2] == '/'
+private fun hasWindowsDriveLetter(path: String): Boolean = path.drop(1).startsWith(":/")
 
 private fun normalizePathForComparison(path: String): String {
-    val normalized = path.replace('\\', '/')
-    return if (hasWindowsDriveLetter(normalized)) normalized.substring(2) else normalized
+    val normalized = pathComparisonKey(path)
+    return if (hasWindowsDriveLetter(normalized)) {
+        normalized.substring(2)
+    } else {
+        normalized
+    }
 }
 
 private fun resolveAbsolutePath(
@@ -63,7 +69,7 @@ class Git4IdeaChangeLister
             workspacePath: String,
             filesToExcludeFromHeuristic: Set<String>,
         ): Set<String> {
-            Log.info("Getting changed files gitRoot=${gitRootPath.substringAfterLast('/')}", "Git4IdeaChangeLister")
+            Log.info("Getting changed files gitRoot=${pathFileName(gitRootPath)}", "Git4IdeaChangeLister")
             val repository = getRepository(gitRootPath)
             if (repository == null) {
                 Log.info("No repository found", "Git4IdeaChangeLister")
@@ -165,7 +171,10 @@ class Git4IdeaChangeLister
 
                     for (filePath in filesList) {
                         val absolutePath = resolveAbsolutePath(fileSystem, gitRootPath, filePath)
-                        val shouldExcludeFromHeuristic = filesToExcludeFromHeuristic.contains(absolutePath)
+                        val shouldExcludeFromHeuristic =
+                            filesToExcludeFromHeuristic.any {
+                                normalizePathForComparison(it) == normalizePathForComparison(absolutePath)
+                            }
                         val exists = fileSystem.fileExists(absolutePath)
                         val reviewable = shouldReviewFile(absolutePath)
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverService.kt
@@ -1,6 +1,7 @@
 package com.codescene.jetbrains.platform.git
 
 import com.codescene.jetbrains.core.git.FileSystemAdapter
+import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.core.review.FileEventHandler
 import com.codescene.jetbrains.platform.api.CachedReviewService
 import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
@@ -126,7 +127,7 @@ class GitChangeObserverService(
             fileSystem = fileSystem,
             gitService = gitService,
             onFileDeleted = { filePath ->
-                val fileName = filePath.substringAfterLast('/')
+                val fileName = pathFileName(filePath)
                 Log.info("File deletion callback path=$fileName", "GitChangeObserverService")
                 ApplicationManager.getApplication().invokeLater {
                     if (project.isDisposed) return@invokeLater
@@ -135,7 +136,7 @@ class GitChangeObserverService(
                 }
             },
             onFileChanged = { filePath ->
-                val fileName = filePath.substringAfterLast('/')
+                val fileName = pathFileName(filePath)
                 ApplicationManager.getApplication().invokeLater {
                     if (project.isDisposed) return@invokeLater
                     val editor = getEditorForFile(filePath)

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitRepoStateListener.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitRepoStateListener.kt
@@ -2,6 +2,9 @@ package com.codescene.jetbrains.platform.git
 
 import com.codescene.jetbrains.core.git.FileEvent
 import com.codescene.jetbrains.core.git.FileEventType
+import com.codescene.jetbrains.core.git.gitRelativeComparisonKey
+import com.codescene.jetbrains.core.git.pathComparisonKey
+import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.platform.util.Log
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
@@ -35,7 +38,7 @@ class GitRepoStateListener(
             GitStagingAreaHolder.TOPIC,
             object : GitStagingAreaHolder.StagingAreaListener {
                 override fun stagingAreaChanged(repository: GitRepository) {
-                    if (repository.root.path == gitRootPath) {
+                    if (pathComparisonKey(repository.root.path) == pathComparisonKey(gitRootPath)) {
                         Log.info("Staging area changed, scheduling reconciliation", "GitRepoStateListener")
                         scheduleReconciliation()
                     }
@@ -63,9 +66,11 @@ class GitRepoStateListener(
         )
 
         for (trackedPath in trackedFiles) {
-            if (!currentChangedFiles.contains(trackedPath)) {
+            val trackedKey = gitRelativeComparisonKey(gitRootPath, trackedPath)
+            val isStillChanged = currentChangedFiles.any { gitRelativeComparisonKey(gitRootPath, it) == trackedKey }
+            if (!isStillChanged) {
                 Log.info(
-                    "Queueing DELETE for file no longer changed: ${trackedPath.substringAfterLast('/')}",
+                    "Queueing DELETE for file no longer changed: ${pathFileName(trackedPath)}",
                     "GitRepoStateListener",
                 )
                 observer.queueEvent(FileEvent(FileEventType.DELETE, trackedPath))

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/PeriodicChangeListerService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/PeriodicChangeListerService.kt
@@ -1,5 +1,6 @@
 package com.codescene.jetbrains.platform.git
 
+import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.platform.api.CachedReviewService
 import com.codescene.jetbrains.platform.util.Log
 import com.intellij.openapi.Disposable
@@ -82,7 +83,7 @@ class PeriodicChangeListerService(
         synchronized(reviewedFiles) {
             val removedFiles = reviewedFiles - changedFiles
             for (file in removedFiles) {
-                Log.info("File no longer changed: ${file.substringAfterLast('/')}", "PeriodicChangeListerService")
+                Log.info("File no longer changed: ${pathFileName(file)}", "PeriodicChangeListerService")
                 reviewedFiles.remove(file)
             }
         }
@@ -93,7 +94,7 @@ class PeriodicChangeListerService(
                 continue
             }
 
-            Log.info("Triggering review for: ${filePath.substringAfterLast('/')}", "PeriodicChangeListerService")
+            Log.info("Triggering review for: ${pathFileName(filePath)}", "PeriodicChangeListerService")
             synchronized(reviewedFiles) { reviewedFiles.add(filePath) }
             CachedReviewService.getInstance(project).reviewByPath(filePath)
         }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/VfsEventBridge.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/VfsEventBridge.kt
@@ -2,6 +2,7 @@ package com.codescene.jetbrains.platform.git
 
 import com.codescene.jetbrains.core.git.FileEvent
 import com.codescene.jetbrains.core.git.FileEventType
+import com.codescene.jetbrains.core.git.isPathUnderRoot
 import com.codescene.jetbrains.platform.util.Log
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
@@ -57,8 +58,7 @@ class VfsEventBridge(
     }
 
     internal fun isWithinWorkspace(path: String): Boolean {
-        val normalizedWorkspace = if (workspacePath.endsWith("/")) workspacePath else "$workspacePath/"
-        return path.startsWith(normalizedWorkspace) || path == workspacePath
+        return isPathUnderRoot(path, workspacePath)
     }
 
     internal fun isGitInternalPath(path: String): Boolean {

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/UpdateMonitor.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/UpdateMonitor.kt
@@ -1,6 +1,7 @@
 package com.codescene.jetbrains.platform.webview.util
 
 import com.codescene.jetbrains.core.flag.RuntimeFlags
+import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.core.mapper.CodeHealthMonitorMapper
 import com.codescene.jetbrains.core.models.View
 import com.codescene.jetbrains.core.review.AceRefactorableFunctionCacheQuery
@@ -45,7 +46,7 @@ private fun updateMonitorImpl(project: Project) {
     val deltaResults = PlatformDeltaCacheService.getInstance(project).getAll()
     val activeJobs = CachedReviewService.getInstance(project).activeReviewCalls.toList()
 
-    val shortNames = activeJobs.map { it.substringAfterLast('/') }
+    val shortNames = activeJobs.map { pathFileName(it) }
     Log.info("Active jobs: $shortNames deltaResults=${deltaResults.size}", "UpdateMonitor")
 
     val update =

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerWindowsPathTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerWindowsPathTest.kt
@@ -1,0 +1,105 @@
+package com.codescene.jetbrains.platform.git
+
+import com.codescene.jetbrains.core.contracts.IFileSystem
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import git4idea.ignore.GitRepositoryIgnoredFilesHolder
+import git4idea.repo.GitRepository
+import git4idea.repo.GitRepositoryManager
+import git4idea.status.GitStagingAreaHolder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class Git4IdeaChangeListerWindowsPathTest {
+    private lateinit var project: Project
+    private lateinit var git4IdeaChangeLister: Git4IdeaChangeLister
+    private lateinit var mockRepository: GitRepository
+    private lateinit var mockRepoManager: GitRepositoryManager
+    private lateinit var mockLocalFileSystem: LocalFileSystem
+    private lateinit var mockVirtualFile: VirtualFile
+    private lateinit var mockStagingArea: GitStagingAreaHolder
+    private lateinit var mockFileSystem: IFileSystem
+    private lateinit var mockGitExecutor: GitCommandExecutor
+    private lateinit var mockIgnoredFilesHolder: GitRepositoryIgnoredFilesHolder
+
+    @Before
+    fun setup() {
+        project = mockk(relaxed = true)
+        mockRepository = mockk(relaxed = true)
+        mockRepoManager = mockk(relaxed = true)
+        mockLocalFileSystem = mockk(relaxed = true)
+        mockVirtualFile = mockk(relaxed = true)
+        mockStagingArea = mockk(relaxed = true)
+        mockFileSystem = mockk(relaxed = true)
+        mockGitExecutor = mockk(relaxed = true)
+        mockIgnoredFilesHolder = mockk(relaxed = true)
+
+        every { mockRepository.ignoredFilesHolder } returns mockIgnoredFilesHolder
+        every { mockIgnoredFilesHolder.containsFile(any()) } returns false
+
+        mockkStatic(GitRepositoryManager::class)
+        every { GitRepositoryManager.getInstance(project) } returns mockRepoManager
+
+        mockkStatic(LocalFileSystem::class)
+        every { LocalFileSystem.getInstance() } returns mockLocalFileSystem
+
+        git4IdeaChangeLister = Git4IdeaChangeLister(project, mockFileSystem, mockGitExecutor)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `getAllChangedFiles matches heuristic exclusions with Windows separator differences`() =
+        runBlocking {
+            val gitRoot = "C:/test/repo"
+            val workspace = "C:/test/repo"
+
+            Git4IdeaTestSupport.setupRepositoryAccess(
+                mockLocalFileSystem,
+                mockRepoManager,
+                mockRepository,
+                mockVirtualFile,
+                gitRoot,
+            )
+            Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
+            every { mockRepository.currentBranchName } returns "master"
+            every { mockGitExecutor.runRevParse(mockRepository) } returns "abc123"
+
+            val files =
+                (1..6).map { i ->
+                    val file = mockk<com.intellij.openapi.vcs.FilePath>()
+                    every { file.path } returns "untracked$i.ts"
+                    file
+                }
+            every { mockRepository.untrackedFilesHolder.retrieveUntrackedFilePaths() } returns files
+
+            files.forEach { file ->
+                val fileName = file.path
+                val absolutePath = "C:\\test\\repo\\$fileName"
+                every { mockFileSystem.getAbsolutePath(gitRoot, fileName) } returns absolutePath
+                every { mockFileSystem.fileExists(absolutePath) } returns true
+                every { mockFileSystem.getExtension(absolutePath) } returns "ts"
+                every { mockFileSystem.getParent(fileName) } returns null
+            }
+
+            val changedFiles =
+                git4IdeaChangeLister.getAllChangedFiles(
+                    gitRoot,
+                    workspace,
+                    setOf("C:/test/repo/untracked2.ts"),
+                )
+
+            assertEquals(setOf("C:\\test\\repo\\untracked2.ts"), changedFiles)
+        }
+}

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/VfsEventBridgeTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/VfsEventBridgeTest.kt
@@ -120,6 +120,14 @@ class VfsEventBridgeTest {
     }
 
     @Test
+    fun `isWithinWorkspace handles Windows separator differences`() {
+        val windowsBridge = VfsEventBridge(project, "C:\\repo", observer)
+        assertTrue(windowsBridge.isWithinWorkspace("C:/repo/src/file.kt"))
+        assertTrue(windowsBridge.isWithinWorkspace("c:/repo/src/file.kt"))
+        assertFalse(windowsBridge.isWithinWorkspace("C:/repo-other/src/file.kt"))
+    }
+
+    @Test
     fun `start subscribes to MessageBus VFS_CHANGES`() {
         val messageBus = mockk<MessageBus>(relaxed = true)
         val connection = mockk<MessageBusConnection>(relaxed = true)


### PR DESCRIPTION
## Summary
- Normalize path comparison/cache keys so Windows drive-letter and separator variants map to same file across delta, baseline, review, git observer, and platform update flows.
- Preserve original file paths for UI/monitor output while using normalized keys internally.
- Add Windows path coverage for cache behavior, git change observation, Git4Idea heuristic exclusions, and workspace filtering.

## Test plan
- CodeScene change-set review vs `integrate-GCO`: passed.
- `make iter`: started, but exceeded the 10 minute project timeout with no output and was stopped.