### PR TITLE
fix: CS-7020: code-health-rules.json support

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/IGitService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/IGitService.kt
@@ -7,5 +7,7 @@ interface IGitService {
 
     fun getRepoRelativePath(filePath: String): String?
 
+    fun getRepoRoot(filePath: String): String?
+
     fun isIgnored(filePath: String): Boolean
 }

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/ExtensionApiCodeHealthRulesIntegrationTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/ExtensionApiCodeHealthRulesIntegrationTest.kt
@@ -10,7 +10,9 @@ import java.nio.file.Path
 import java.util.Optional
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeNotNull
 import org.junit.Before
 import org.junit.Test
 
@@ -53,15 +55,17 @@ class ExtensionApiCodeHealthRulesIntegrationTest {
 
         val defaultDelta = delta("src/BumpyRoad.cs", simpleCSharpCode, bumpyRoadCSharpCode, defaultRepo)
         val rulesDelta = delta("src/BumpyRoad.cs", simpleCSharpCode, bumpyRoadCSharpCode, rulesRepo)
-        val defaultNewScore = optionalScore(checkNotNull(defaultDelta).newScore)
+        assertNotNull("default delta should be present", defaultDelta)
+        val defaultNewScore = optionalScore(defaultDelta!!.newScore)
 
         assertTrue("default rules should report Bumpy Road degradation", defaultNewScore < 10.0)
-        if (rulesDelta == null) return
+        assumeNotNull(rulesDelta)
+        val rulesNewScore = optionalScore(rulesDelta!!.newScore)
         assertTrue(
             "code-health-rules should improve delta new score",
-            optionalScore(rulesDelta.newScore) > defaultNewScore,
+            rulesNewScore > defaultNewScore,
         )
-        assertEquals(10.0, optionalScore(rulesDelta.newScore), 0.01)
+        assertEquals(10.0, rulesNewScore, 0.01)
     }
 
     private fun review(

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/ExtensionApiCodeHealthRulesIntegrationTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/ExtensionApiCodeHealthRulesIntegrationTest.kt
@@ -1,0 +1,229 @@
+package com.codescene.jetbrains.core.review
+
+import com.codescene.ExtensionAPI
+import com.codescene.ExtensionAPI.CacheParams
+import com.codescene.ExtensionAPI.ReviewParams
+import com.codescene.data.delta.Delta
+import com.codescene.data.review.Review
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Optional
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ExtensionApiCodeHealthRulesIntegrationTest {
+    private lateinit var cacheDir: Path
+    private val tempRoots = mutableListOf<Path>()
+
+    @Before
+    fun setUp() {
+        cacheDir = Files.createTempDirectory("codescene-extension-api-cache")
+    }
+
+    @After
+    fun tearDown() {
+        cacheDir.toFile().deleteRecursively()
+        tempRoots.forEach { it.toFile().deleteRecursively() }
+        tempRoots.clear()
+    }
+
+    @Test
+    fun `review applies code health rules from repo root`() {
+        val rulesRepo = prepareGitRepoWithRules("src/BumpyRoad.cs", bumpyRoadCSharpCode)
+        val defaultRepo = prepareGitRepoWithoutRules("src/BumpyRoad.cs", bumpyRoadCSharpCode)
+
+        val defaultReview = review("src/BumpyRoad.cs", bumpyRoadCSharpCode, defaultRepo)
+        val rulesReview = review("src/BumpyRoad.cs", bumpyRoadCSharpCode, rulesRepo)
+
+        assertTrue(
+            "code-health-rules should improve Bumpy Road score",
+            reviewScore(rulesReview) > reviewScore(defaultReview),
+        )
+        assertEquals(10.0, reviewScore(rulesReview), 0.01)
+        assertEquals(0, totalSmellCount(rulesReview))
+    }
+
+    @Test
+    fun `delta applies code health rules from repo root`() {
+        val rulesRepo = prepareGitRepoWithRules("src/BumpyRoad.cs", bumpyRoadCSharpCode)
+        val defaultRepo = prepareGitRepoWithoutRules("src/BumpyRoad.cs", bumpyRoadCSharpCode)
+
+        val defaultDelta = delta("src/BumpyRoad.cs", simpleCSharpCode, bumpyRoadCSharpCode, defaultRepo)
+        val rulesDelta = delta("src/BumpyRoad.cs", simpleCSharpCode, bumpyRoadCSharpCode, rulesRepo)
+        val defaultNewScore = optionalScore(checkNotNull(defaultDelta).newScore)
+
+        assertTrue("default rules should report Bumpy Road degradation", defaultNewScore < 10.0)
+        if (rulesDelta == null) return
+        assertTrue(
+            "code-health-rules should improve delta new score",
+            optionalScore(rulesDelta.newScore) > defaultNewScore,
+        )
+        assertEquals(10.0, optionalScore(rulesDelta.newScore), 0.01)
+    }
+
+    private fun review(
+        fileName: String,
+        code: String,
+        repoRoot: Path,
+    ): Review =
+        ExtensionAPI.review(
+            ReviewParams("./$fileName", code, repoRoot.toString()),
+            cacheParams(),
+        )
+
+    private fun delta(
+        fileName: String,
+        oldCode: String,
+        newCode: String,
+        repoRoot: Path,
+    ): Delta? =
+        ExtensionAPI.delta(
+            ReviewParams("./$fileName", oldCode, repoRoot.toString()),
+            ReviewParams("./$fileName", newCode, repoRoot.toString()),
+            cacheParams(),
+        )
+
+    private fun cacheParams(): CacheParams = CacheParams(cacheDir.toString())
+
+    private fun prepareGitRepoWithRules(
+        sourceRelativePath: String,
+        sourceContent: String,
+    ): Path =
+        prepareGitRepo(sourceRelativePath, sourceContent).also { repoRoot ->
+            writeRepoFile(repoRoot, ".codescene/code-health-rules.json", rulesBumpyRoadWeight0)
+            runGit(repoRoot, "add", ".")
+            runGit(repoRoot, "commit", "-m", "test")
+        }
+
+    private fun prepareGitRepoWithoutRules(
+        sourceRelativePath: String,
+        sourceContent: String,
+    ): Path =
+        prepareGitRepo(sourceRelativePath, sourceContent).also { repoRoot ->
+            runGit(repoRoot, "add", ".")
+            runGit(repoRoot, "commit", "-m", "test")
+        }
+
+    private fun prepareGitRepo(
+        sourceRelativePath: String,
+        sourceContent: String,
+    ): Path {
+        val repoRoot = Files.createTempDirectory("codescene-extension-api-rules")
+        tempRoots.add(repoRoot)
+        runGit(repoRoot, "init")
+        runGit(repoRoot, "config", "user.email", "test@example.com")
+        runGit(repoRoot, "config", "user.name", "Test User")
+        writeRepoFile(repoRoot, sourceRelativePath, sourceContent)
+        return repoRoot
+    }
+
+    private fun writeRepoFile(
+        repoRoot: Path,
+        relativePath: String,
+        content: String,
+    ) {
+        val path = repoRoot.resolve(relativePath)
+        Files.createDirectories(path.parent)
+        Files.writeString(path, content)
+    }
+
+    private fun runGit(
+        repoRoot: Path,
+        vararg args: String,
+    ) {
+        val process =
+            ProcessBuilder(listOf("git", *args))
+                .directory(repoRoot.toFile())
+                .redirectErrorStream(true)
+                .start()
+        val output = process.inputStream.bufferedReader().readText()
+        val exitCode = process.waitFor()
+        check(exitCode == 0) { "git ${args.joinToString(" ")} failed with exit code $exitCode: $output" }
+    }
+
+    private fun reviewScore(review: Review): Double = optionalScore(review.score)
+
+    private fun optionalScore(score: Optional<Double>): Double {
+        assertTrue("score should be present", score.isPresent)
+        return score.get()
+    }
+
+    private fun totalSmellCount(review: Review): Int =
+        review.fileLevelCodeSmells.size + review.functionLevelCodeSmells.sumOf { it.codeSmells.size }
+
+    private val simpleCSharpCode =
+        """
+        namespace CodeScene.ExtensionApi.Tests;
+
+        public static class Calculator
+        {
+            public static int Add(int a, int b) => a + b;
+        }
+        """.trimIndent()
+
+    private val bumpyRoadCSharpCode =
+        """
+        using System.Collections.Generic;
+        using System.IO;
+        using System.Text;
+        using System.Text.RegularExpressions;
+
+        namespace CodeScene.ExtensionApi.Tests
+        {
+            class BumpyRoadExample
+            {
+                public void ProcessDirectory(string path)
+                {
+                    var files = new List<string>();
+                    var directory = new DirectoryInfo(path);
+
+                    foreach (FileInfo fileInfo in directory.GetFiles())
+                    {
+                        if (Regex.IsMatch(fileInfo.Name, @"^data\d+\.csv${'$'}"))
+                        {
+                            files.Add(fileInfo.FullName);
+                        }
+                    }
+
+                    var sb = new StringBuilder();
+                    foreach (string filePath in files)
+                    {
+                        using (var reader = new StreamReader(filePath))
+                        {
+                            string line;
+                            while ((line = reader.ReadLine()) != null)
+                            {
+                                sb.Append(line);
+                            }
+                        }
+                    }
+
+                    using (var writer = new StreamWriter("data.csv"))
+                    {
+                        writer.Write(sb.ToString());
+                    }
+                }
+            }
+        }
+        """.trimIndent()
+
+    private val rulesBumpyRoadWeight0 =
+        """
+        {
+          "rule_sets": [
+            {
+              "matching_content_path": "**/*",
+              "rules": [
+                {
+                  "name": "Bumpy Road Ahead",
+                  "weight": 0.0
+                }
+              ]
+            }
+          ]
+        }
+        """.trimIndent()
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/ExtensionApiIntegrationTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/ExtensionApiIntegrationTest.kt
@@ -18,20 +18,26 @@ import org.junit.Test
 
 class ExtensionApiIntegrationTest {
     private lateinit var cacheDir: Path
+    private lateinit var defaultRepoRoot: Path
+    private val tempRoots = mutableListOf<Path>()
 
     @Before
     fun setUp() {
         cacheDir = Files.createTempDirectory("codescene-extension-api-cache")
+        defaultRepoRoot = Files.createTempDirectory("codescene-extension-api-repo")
+        tempRoots.add(defaultRepoRoot)
     }
 
     @After
     fun tearDown() {
         cacheDir.toFile().deleteRecursively()
+        tempRoots.forEach { it.toFile().deleteRecursively() }
+        tempRoots.clear()
     }
 
     @Test
     fun `review returns valid response for Kotlin code`() {
-        val review = review("ReviewSubject.kt", simpleKotlinCode)
+        val review = review("ReviewSubject.kt", simpleKotlinCode, defaultRepoRoot)
 
         assertReview(review)
     }
@@ -40,8 +46,8 @@ class ExtensionApiIntegrationTest {
     fun `delta returns valid response for changed Kotlin code`() {
         val delta =
             ExtensionAPI.delta(
-                ReviewParams("./DeltaSubject.kt", simpleKotlinCode),
-                ReviewParams("./DeltaSubject.kt", complexKotlinCode),
+                ReviewParams("./DeltaSubject.kt", simpleKotlinCode, defaultRepoRoot.toString()),
+                ReviewParams("./DeltaSubject.kt", complexKotlinCode, defaultRepoRoot.toString()),
                 cacheParams(),
             )
 
@@ -50,7 +56,7 @@ class ExtensionApiIntegrationTest {
 
     @Test
     fun `fnToRefactor accepts review findings`() {
-        val review = review("AceReviewSubject.kt", complexKotlinCode)
+        val review = review("AceReviewSubject.kt", complexKotlinCode, defaultRepoRoot)
         val codeSmells = review.fileLevelCodeSmells + review.functionLevelCodeSmells.flatMap { it.codeSmells }
 
         val functions =
@@ -67,8 +73,8 @@ class ExtensionApiIntegrationTest {
     fun `fnToRefactor accepts delta response`() {
         val delta =
             ExtensionAPI.delta(
-                ReviewParams("./AceDeltaSubject.kt", simpleKotlinCode),
-                ReviewParams("./AceDeltaSubject.kt", complexKotlinCode),
+                ReviewParams("./AceDeltaSubject.kt", simpleKotlinCode, defaultRepoRoot.toString()),
+                ReviewParams("./AceDeltaSubject.kt", complexKotlinCode, defaultRepoRoot.toString()),
                 cacheParams(),
             )
 
@@ -85,9 +91,10 @@ class ExtensionApiIntegrationTest {
     private fun review(
         fileName: String,
         code: String,
+        repoRoot: Path,
     ): Review =
         ExtensionAPI.review(
-            ReviewParams("./$fileName", code),
+            ReviewParams("./$fileName", code, repoRoot.toString()),
             cacheParams(),
         )
 

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/StubGitService.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/StubGitService.kt
@@ -6,10 +6,12 @@ class StubGitService(
     private val contentByPath: Map<String, String> = emptyMap(),
     private val commitHashByPath: Map<String, String?> = emptyMap(),
     private val repoRelativePathByPath: Map<String, String?> = emptyMap(),
+    private val repoRootByPath: Map<String, String?> = emptyMap(),
     private val ignoredByPath: Map<String, Boolean> = emptyMap(),
     private val defaultContent: String = "",
     private val defaultCommitHash: String? = null,
     private val defaultRepoRelativePath: String? = null,
+    private val defaultRepoRoot: String? = null,
     private val defaultIgnored: Boolean = false,
 ) : IGitService {
     override fun getBranchCreationCommitCode(filePath: String): String {
@@ -22,6 +24,10 @@ class StubGitService(
 
     override fun getRepoRelativePath(filePath: String): String? {
         return repoRelativePathByPath[filePath] ?: defaultRepoRelativePath
+    }
+
+    override fun getRepoRoot(filePath: String): String? {
+        return repoRootByPath[filePath] ?: defaultRepoRoot
     }
 
     override fun isIgnored(filePath: String): Boolean {

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/util/GitIgnoreSupportTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/util/GitIgnoreSupportTest.kt
@@ -153,6 +153,8 @@ class GitIgnoreSupportTest {
 
         override fun getRepoRelativePath(filePath: String): String? = null
 
+        override fun getRepoRoot(filePath: String): String? = repoRoot.toString()
+
         override fun isIgnored(filePath: String): Boolean {
             val relativePath = repoRoot.relativize(Paths.get(filePath)).normalize().toGitPath()
             val result =

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ org.gradle.configuration-cache = false
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching = true
 
-codeSceneExtensionAPIVersion = 1.0-6212d91
+codeSceneExtensionAPIVersion = 1.0-5b5b244
 codeSceneRepository = https://maven.pkg.github.com/empear-analytics/codescene-ide-protocol
 mockkVersion = 1.14.9
 kotlinxSerializationVersion = 1.9.0

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/CodeDeltaService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/CodeDeltaService.kt
@@ -52,10 +52,14 @@ class CodeDeltaService(private val project: Project) : com.codescene.jetbrains.c
             )
         val currentReviewPath = resolveCliCacheFileName(path, repoRelativePath)
 
-        val oldReview = ReviewParams(baselineReviewPath, oldCode)
-        val newReview = ReviewParams(currentReviewPath, currentCode)
+        val repoRoot = resolveRepoRoot(path)
+        val oldReview = ReviewParams(baselineReviewPath, oldCode, repoRoot)
+        val newReview = ReviewParams(currentReviewPath, currentCode, repoRoot)
         val cacheParams = CacheParams(serviceProvider.cliCacheService.getCachePath())
-        val (rawResult, elapsedMs) = runWithClassLoaderChange { ExtensionAPI.delta(oldReview, newReview, cacheParams) }
+        val (rawResult, elapsedMs) =
+            runWithClassLoaderChange {
+                ExtensionAPI.delta(oldReview, newReview, cacheParams)
+            }
         val delta = adaptDeltaResult(rawResult)
         StatsCollectorService.getInstance().recordAnalysis(editor.virtualFile.name, elapsedMs.toDouble())
 
@@ -79,4 +83,7 @@ class CodeDeltaService(private val project: Project) : com.codescene.jetbrains.c
             )
         return result
     }
+
+    private fun resolveRepoRoot(path: String): String =
+        gitService.getRepoRoot(path) ?: project.basePath ?: path.substringBeforeLast('/', path)
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/CodeReviewService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/CodeReviewService.kt
@@ -82,7 +82,8 @@ class CodeReviewService(private val project: Project) : com.codescene.jetbrains.
         code: String,
         cacheResult: Boolean,
     ): Review? {
-        val params = ReviewParams(reviewPath, code)
+        val repoRoot = resolveRepoRoot(path)
+        val params = ReviewParams(reviewPath, code, repoRoot)
         val cacheParams = CacheParams(serviceProvider.cliCacheService.getCachePath())
         val (result, elapsedMs) = runWithClassLoaderChange { ExtensionAPI.review(params, cacheParams) }
         result ?: return null
@@ -118,4 +119,7 @@ class CodeReviewService(private val project: Project) : com.codescene.jetbrains.
 
         return result
     }
+
+    private fun resolveRepoRoot(path: String): String =
+        gitService.getRepoRoot(path) ?: project.basePath ?: path.substringBeforeLast('/', path)
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
@@ -39,7 +39,8 @@ class Git4IdeaGitService(val project: Project) : IGitService {
      * - Fallback: branch-creation commit from the current branch’s reflog (same as the previous JetBrains-only behavior).
      */
     override fun getBranchCreationCommitCode(filePath: String): String {
-        val context = getRepositoryContext(filePath) ?: return ""
+        val file = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return ""
+        val context = getRepositoryContext(file) ?: return ""
 
         if (context.repository.state == Repository.State.DETACHED) return ""
 
@@ -49,11 +50,23 @@ class Git4IdeaGitService(val project: Project) : IGitService {
                 return ""
             }
 
-        return getCodeByCommit(context.repository, context.relativePath, commit)
+        val handler =
+            createGitLineHandler(project, context.repository.root, GitCommand.SHOW).apply {
+                addParameters("$commit:${context.relativePath}")
+            }
+
+        return Git.getInstance().runCommand(handler).let {
+            if (it.success()) {
+                it.output.joinToString("\n").replace("\r\n", "\n").replace('\r', '\n')
+            } else {
+                ""
+            }
+        }
     }
 
     override fun getBranchCreationCommitHash(filePath: String): String? {
-        val context = getRepositoryContext(filePath) ?: return null
+        val file = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return null
+        val context = getRepositoryContext(file) ?: return null
 
         if (context.repository.state == Repository.State.DETACHED) {
             return null
@@ -62,24 +75,30 @@ class Git4IdeaGitService(val project: Project) : IGitService {
         return getBaselineCommitSha(context.repository)
     }
 
-    override fun getRepoRelativePath(filePath: String): String? = getRepositoryContext(filePath)?.relativePath
+    override fun getRepoRelativePath(filePath: String): String? =
+        LocalFileSystem.getInstance()
+            .findFileByPath(filePath)
+            ?.let { file -> getRepositoryContext(file)?.relativePath }
+
+    override fun getRepoRoot(filePath: String): String? =
+        LocalFileSystem.getInstance()
+            .findFileByPath(filePath)
+            ?.let { file -> getRepositoryContext(file)?.repository?.root?.path }
 
     override fun isIgnored(filePath: String): Boolean {
-        val context = getRepositoryContext(filePath) ?: return false
+        val file = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return false
+        val context = getRepositoryContext(file) ?: return false
         return context.repository.ignoredFilesHolder.containsFile(VcsUtil.getFilePath(context.file))
     }
-
-    private fun isMainLineBranch(branchName: String): Boolean =
-        MAIN_BRANCH_NAMES.any { it.equals(branchName, ignoreCase = true) }
 
     private fun getBaselineCommitSha(gitRepository: GitRepository): String? {
         val branchName = gitRepository.currentBranchName ?: return null
 
-        if (isMainLineBranch(branchName)) {
+        if (MAIN_BRANCH_NAMES.any { it.equals(branchName, ignoreCase = true) }) {
             return resolveHeadCommitSha(gitRepository)
         }
 
-        val mergeBase = findMergeBaseWithMain(gitRepository, branchName)
+        val mergeBase = findMergeBaseWithMain(gitRepository)
         if (!mergeBase.isNullOrBlank()) {
             return mergeBase.trim()
         }
@@ -101,10 +120,8 @@ class Git4IdeaGitService(val project: Project) : IGitService {
         }
     }
 
-    private fun findMergeBaseWithMain(
-        gitRepository: GitRepository,
-        currentBranchName: String,
-    ): String? {
+    private fun findMergeBaseWithMain(gitRepository: GitRepository): String? {
+        val currentBranchName = gitRepository.currentBranchName ?: return null
         for (mainName in MAIN_BRANCH_NAMES) {
             val refsToTry =
                 listOf(
@@ -112,29 +129,23 @@ class Git4IdeaGitService(val project: Project) : IGitService {
                     "origin/$mainName",
                 )
             for (ref in refsToTry) {
-                val mergeBase = runMergeBase(gitRepository, currentBranchName, ref)
+                val handler =
+                    createGitLineHandler(project, gitRepository.root, GitCommand.MERGE_BASE).apply {
+                        addParameters(currentBranchName, ref)
+                    }
+                val result = Git.getInstance().runCommand(handler)
+                val mergeBase =
+                    if (result.success()) {
+                        result.output.firstOrNull()?.trim()?.takeIf { it.isNotEmpty() }
+                    } else {
+                        null
+                    }
                 if (!mergeBase.isNullOrBlank()) {
                     return mergeBase.trim()
                 }
             }
         }
         return null
-    }
-
-    private fun runMergeBase(
-        gitRepository: GitRepository,
-        rev1: String,
-        rev2: String,
-    ): String? {
-        val handler =
-            createGitLineHandler(project, gitRepository.root, GitCommand.MERGE_BASE).apply {
-                addParameters(rev1, rev2)
-            }
-        val result = Git.getInstance().runCommand(handler)
-        if (!result.success()) {
-            return null
-        }
-        return result.output.firstOrNull()?.trim()?.takeIf { it.isNotEmpty() }
     }
 
     private fun getBranchCreationCommitFromReflog(gitRepository: GitRepository): String? =
@@ -158,29 +169,7 @@ class Git4IdeaGitService(val project: Project) : IGitService {
         }
     }
 
-    private fun getCodeByCommit(
-        gitRepository: GitRepository,
-        relativePath: String,
-        commit: String,
-    ): String {
-        val handler =
-            createGitLineHandler(project, gitRepository.root, GitCommand.SHOW).apply {
-                addParameters("$commit:$relativePath")
-            }
-
-        Git.getInstance().runCommand(handler).let {
-            if (it.success()) {
-                return normalizeVcsLineSeparators(it.output.joinToString("\n"))
-            } else {
-                return ""
-            }
-        }
-    }
-
-    private fun normalizeVcsLineSeparators(text: String): String = text.replace("\r\n", "\n").replace('\r', '\n')
-
-    private fun getRepositoryContext(filePath: String): RepositoryContext? {
-        val file = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return null
+    private fun getRepositoryContext(file: VirtualFile): RepositoryContext? {
         val repository =
             GitRepositoryManager.getInstance(project).getRepositoryForFile(file) ?: run {
                 Log.debug("File ${file.path} is not part of a Git repository.", service)


### PR DESCRIPTION
Updated to new version of codescene-ide-protocol which has support for sending the path of the git repo root for review and delta commands, which fixes support for reading .codescene/code-health-rules.json