### PR TITLE
Add ExtensionAPI benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,7 +2,6 @@ name: Benchmark Review Paths
 
 on:
   workflow_dispatch:
-  pull_request: 
   push:
     branches:
       - master

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,6 +2,7 @@ name: Benchmark Review Paths
 
 on:
   workflow_dispatch:
+  pull_request: 
   push:
     branches:
       - master

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,55 @@
+name: Benchmark Review Paths
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  deployments: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GH_USERNAME: ${{ secrets.GH_USERNAME }}
+  GH_PACKAGE_TOKEN: ${{ secrets.GH_PACKAGE_TOKEN }}
+
+jobs:
+  benchmarks:
+    name: Run ExtensionAPI benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-excludes: |
+            caches/modules-2/files-2.1/idea/**
+            caches/**/transforms/**
+
+      - name: Run ExtensionAPI benchmarks
+        run: ./gradlew :benchmarks:jmh
+
+      - name: Store ExtensionAPI benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: JetBrains Plugin - ExtensionAPI
+          tool: 'jmh'
+          output-file-path: benchmarks/build/reports/jmh/results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@martinsafsten-codescene'

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GRADLEW := ./gradlew
 NULL := /dev/null
 endif
 
-.PHONY: install-cli check-bb build test format format-check delta iter coverage-summary bump-version release test-release class-size-mine
+.PHONY: install-cli check-bb build test benchmarks format format-check delta iter coverage-summary bump-version release test-release class-size-mine
 
 install-cli: check-bb
 	@$(BB) -f .github/install-cli.clj
@@ -18,8 +18,9 @@ check-bb:
 KT_FILES := $(wildcard src/main/kotlin/**/*.kt) \
             $(wildcard src/test/kotlin/**/*.kt) \
             $(wildcard core/src/main/kotlin/**/*.kt) \
-            $(wildcard core/src/test/kotlin/**/*.kt)
-GRADLE_FILES := $(wildcard build.gradle.kts) $(wildcard core/build.gradle.kts) $(wildcard settings.gradle.kts) $(wildcard gradle.properties) $(wildcard gradle/libs.versions.toml)
+            $(wildcard core/src/test/kotlin/**/*.kt) \
+            $(wildcard benchmarks/src/jmh/kotlin/**/*.kt)
+GRADLE_FILES := $(wildcard build.gradle.kts) $(wildcard core/build.gradle.kts) $(wildcard benchmarks/build.gradle.kts) $(wildcard settings.gradle.kts) $(wildcard gradle.properties) $(wildcard gradle/libs.versions.toml)
 
 .build-timestamp: check-bb $(KT_FILES) $(GRADLE_FILES)
 	@$(BB) -f .github/run-quiet.clj build.log "gradle buildPlugin" $(GRADLEW) --rerun-tasks --warn buildPlugin
@@ -29,6 +30,9 @@ build: .build-timestamp
 
 test: check-bb build
 	@$(BB) -f .github/run-quiet.clj test.log "gradle test" $(GRADLEW) test
+
+benchmarks: check-bb
+	@$(BB) -f .github/run-quiet.clj benchmarks.log "gradle benchmarks" $(GRADLEW) :benchmarks:jmh
 
 format: check-bb
 	@$(BB) -f .github/run-quiet.clj format.log "gradle ktlintFormat" $(GRADLEW) ktlintFormat

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -1,0 +1,65 @@
+import org.gradle.api.file.DuplicatesStrategy
+
+plugins {
+    alias(libs.plugins.kotlin)
+    alias(libs.plugins.jmh)
+    alias(libs.plugins.ktlint)
+}
+
+group = rootProject.group
+version = rootProject.version
+
+kotlin {
+    jvmToolchain(17)
+}
+
+val codeSceneExtensionAPIVersion = rootProject.providers.gradleProperty("codeSceneExtensionAPIVersion").get()
+val codeSceneRepository = rootProject.providers.gradleProperty("codeSceneRepository").get()
+val slf4jNopVersion = rootProject.providers.gradleProperty("slf4jNopVersion").get()
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven {
+        url = uri(codeSceneRepository)
+        credentials {
+            username = System.getenv("GH_USERNAME")
+            password = System.getenv("GH_PACKAGE_TOKEN")
+        }
+    }
+}
+
+dependencies {
+    add("jmh", project(":core"))
+    add("jmh", kotlin("stdlib"))
+    add("jmh", "codescene.extension:api:$codeSceneExtensionAPIVersion")
+    add("jmhRuntimeOnly", "org.slf4j:slf4j-nop:$slf4jNopVersion")
+}
+
+jmh {
+    benchmarkMode = listOf("avgt")
+    timeUnit = "ms"
+    warmupIterations = 2
+    iterations = 5
+    fork = 1
+    resultFormat = "JSON"
+    resultsFile = project.file("${layout.buildDirectory.get().asFile}/reports/jmh/results.json")
+    duplicateClassesStrategy = DuplicatesStrategy.WARN
+}
+
+val ktlintFailOnError =
+    rootProject.providers.gradleProperty("ktlintFailOnError")
+        .map(String::toBoolean)
+        .orElse(false)
+
+ktlint {
+    ignoreFailures.set(ktlintFailOnError.map { failOnError -> !failOnError })
+    version.set("1.2.1")
+    android.set(false)
+    outputToConsole.set(true)
+    enableExperimentalRules.set(false)
+    filter {
+        exclude("**/generated/**")
+        exclude("**/build/**")
+    }
+}

--- a/benchmarks/src/jmh/kotlin/com/codescene/jetbrains/benchmarks/BenchmarkFixtures.kt
+++ b/benchmarks/src/jmh/kotlin/com/codescene/jetbrains/benchmarks/BenchmarkFixtures.kt
@@ -1,0 +1,108 @@
+package com.codescene.jetbrains.benchmarks
+
+import com.codescene.ExtensionAPI.CacheParams
+import com.codescene.ExtensionAPI.CodeParams
+import com.codescene.ExtensionAPI.ReviewParams
+import com.codescene.data.delta.Delta
+import com.codescene.data.review.Review
+import com.codescene.jetbrains.core.util.resolveBaselineCliCacheFileName
+import com.codescene.jetbrains.core.util.resolveCliCacheFileName
+import java.nio.file.Files
+import java.nio.file.Path
+
+class BenchmarkEnvironment {
+    private val tempRoots = mutableListOf<Path>()
+
+    val cacheDir: Path = createTempRoot("codescene-extension-api-cache")
+    val repoRoot: Path = createTempRoot("codescene-extension-api-repo")
+    val cacheParams: CacheParams = CacheParams(cacheDir.toString())
+
+    fun currentReviewParams(
+        suffix: String,
+        code: String = BenchmarkInputs.complexKotlinCode,
+    ): ReviewParams =
+        ReviewParams(
+            currentReviewPath(suffix),
+            code,
+            repoRoot.toString(),
+        )
+
+    fun baselineReviewParams(
+        suffix: String,
+        code: String = BenchmarkInputs.simpleKotlinCode,
+    ): ReviewParams =
+        ReviewParams(
+            baselineReviewPath(suffix),
+            code,
+            repoRoot.toString(),
+        )
+
+    fun codeParams(suffix: String): CodeParams =
+        CodeParams(BenchmarkInputs.complexKotlinCode, currentReviewPath(suffix))
+
+    fun close() {
+        tempRoots.asReversed().forEach { root ->
+            root.toFile().deleteRecursively()
+        }
+        tempRoots.clear()
+    }
+
+    private fun currentReviewPath(suffix: String): String {
+        val relativePath = relativePath(suffix)
+        return resolveCliCacheFileName(repoRoot.resolve(relativePath).toString(), relativePath)
+    }
+
+    private fun baselineReviewPath(suffix: String): String {
+        val relativePath = relativePath(suffix)
+        return resolveBaselineCliCacheFileName(
+            filePath = repoRoot.resolve(relativePath).toString(),
+            repoRelativePath = relativePath,
+            commitSha = "benchmark-base",
+        )
+    }
+
+    private fun relativePath(suffix: String): String =
+        "src/main/kotlin/com/example/Benchmarked${suffix.replace('-', '_')}.kt"
+
+    private fun createTempRoot(prefix: String): Path {
+        val root = Files.createTempDirectory(prefix)
+        tempRoots.add(root)
+        return root
+    }
+}
+
+data class ReviewDeltaFlowResult(
+    val currentReview: Review,
+    val baselineReview: Review,
+    val delta: Delta,
+)
+
+object BenchmarkInputs {
+    val simpleKotlinCode =
+        """
+        class Calculator {
+            fun add(a: Int, b: Int): Int = a + b
+        }
+        """.trimIndent()
+
+    val complexKotlinCode =
+        """
+        class ComplexProcessor {
+            fun process(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int): Int {
+                if (a > 0) {
+                    if (b > 0) {
+                        if (c > 0) {
+                            if (d > 0) {
+                                if (e > 0) {
+                                    return a + b + c + d + e + f + g + h
+                                }
+                            }
+                        }
+                    }
+                }
+
+                return 0
+            }
+        }
+        """.trimIndent()
+}

--- a/benchmarks/src/jmh/kotlin/com/codescene/jetbrains/benchmarks/ExtensionApiDeltaBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/com/codescene/jetbrains/benchmarks/ExtensionApiDeltaBenchmark.kt
@@ -1,0 +1,45 @@
+package com.codescene.jetbrains.benchmarks
+
+import com.codescene.ExtensionAPI
+import com.codescene.ExtensionAPI.ReviewParams
+import com.codescene.data.delta.Delta
+import java.util.concurrent.atomic.AtomicInteger
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+
+@State(Scope.Thread)
+open class ExtensionApiDeltaBenchmark {
+    private lateinit var environment: BenchmarkEnvironment
+    private lateinit var warmBaseline: ReviewParams
+    private lateinit var warmCurrent: ReviewParams
+    private val coldCounter = AtomicInteger()
+
+    @Setup
+    fun setup() {
+        environment = BenchmarkEnvironment()
+        warmBaseline = environment.baselineReviewParams("delta-warm")
+        warmCurrent = environment.currentReviewParams("delta-warm")
+        ExtensionAPI.delta(warmBaseline, warmCurrent, environment.cacheParams)
+    }
+
+    @TearDown
+    fun tearDown() {
+        environment.close()
+    }
+
+    @Benchmark
+    fun deltaCold(): Delta {
+        val suffix = "delta-cold-${coldCounter.incrementAndGet()}"
+        return ExtensionAPI.delta(
+            environment.baselineReviewParams(suffix),
+            environment.currentReviewParams(suffix),
+            environment.cacheParams,
+        )
+    }
+
+    @Benchmark
+    fun deltaWarm(): Delta = ExtensionAPI.delta(warmBaseline, warmCurrent, environment.cacheParams)
+}

--- a/benchmarks/src/jmh/kotlin/com/codescene/jetbrains/benchmarks/ExtensionApiFnToRefactorBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/com/codescene/jetbrains/benchmarks/ExtensionApiFnToRefactorBenchmark.kt
@@ -1,0 +1,55 @@
+package com.codescene.jetbrains.benchmarks
+
+import com.codescene.ExtensionAPI
+import com.codescene.data.ace.FnToRefactor
+import com.codescene.data.delta.Delta
+import java.util.concurrent.atomic.AtomicInteger
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+
+@State(Scope.Thread)
+open class ExtensionApiFnToRefactorBenchmark {
+    private lateinit var environment: BenchmarkEnvironment
+    private lateinit var delta: Delta
+    private val coldCounter = AtomicInteger()
+
+    @Setup
+    fun setup() {
+        environment = BenchmarkEnvironment()
+        delta =
+            ExtensionAPI.delta(
+                environment.baselineReviewParams("fn-to-refactor-delta"),
+                environment.currentReviewParams("fn-to-refactor-delta"),
+                environment.cacheParams,
+            )
+        ExtensionAPI.fnToRefactor(
+            environment.codeParams("fn-to-refactor-warm"),
+            environment.cacheParams,
+            delta,
+        )
+    }
+
+    @TearDown
+    fun tearDown() {
+        environment.close()
+    }
+
+    @Benchmark
+    fun fnToRefactorCold(): List<FnToRefactor> =
+        ExtensionAPI.fnToRefactor(
+            environment.codeParams("fn-to-refactor-cold-${coldCounter.incrementAndGet()}"),
+            environment.cacheParams,
+            delta,
+        )
+
+    @Benchmark
+    fun fnToRefactorWarm(): List<FnToRefactor> =
+        ExtensionAPI.fnToRefactor(
+            environment.codeParams("fn-to-refactor-warm"),
+            environment.cacheParams,
+            delta,
+        )
+}

--- a/benchmarks/src/jmh/kotlin/com/codescene/jetbrains/benchmarks/ExtensionApiReviewBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/com/codescene/jetbrains/benchmarks/ExtensionApiReviewBenchmark.kt
@@ -1,0 +1,56 @@
+package com.codescene.jetbrains.benchmarks
+
+import com.codescene.ExtensionAPI
+import com.codescene.data.review.Review
+import java.util.concurrent.atomic.AtomicInteger
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+
+@State(Scope.Thread)
+open class ExtensionApiReviewBenchmark {
+    private lateinit var environment: BenchmarkEnvironment
+    private val coldCounter = AtomicInteger()
+
+    @Setup
+    fun setup() {
+        environment = BenchmarkEnvironment()
+        ExtensionAPI.review(environment.currentReviewParams("review-warm"), environment.cacheParams)
+        ExtensionAPI.review(environment.baselineReviewParams("baseline-warm"), environment.cacheParams)
+    }
+
+    @TearDown
+    fun tearDown() {
+        environment.close()
+    }
+
+    @Benchmark
+    fun reviewCold(): Review =
+        ExtensionAPI.review(
+            environment.currentReviewParams("review-cold-${coldCounter.incrementAndGet()}"),
+            environment.cacheParams,
+        )
+
+    @Benchmark
+    fun reviewWarm(): Review =
+        ExtensionAPI.review(
+            environment.currentReviewParams("review-warm"),
+            environment.cacheParams,
+        )
+
+    @Benchmark
+    fun baselineReviewCold(): Review =
+        ExtensionAPI.review(
+            environment.baselineReviewParams("baseline-cold-${coldCounter.incrementAndGet()}"),
+            environment.cacheParams,
+        )
+
+    @Benchmark
+    fun baselineReviewWarm(): Review =
+        ExtensionAPI.review(
+            environment.baselineReviewParams("baseline-warm"),
+            environment.cacheParams,
+        )
+}

--- a/benchmarks/src/jmh/kotlin/com/codescene/jetbrains/benchmarks/ReviewDeltaFlowBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/com/codescene/jetbrains/benchmarks/ReviewDeltaFlowBenchmark.kt
@@ -1,0 +1,41 @@
+package com.codescene.jetbrains.benchmarks
+
+import com.codescene.ExtensionAPI
+import java.util.concurrent.atomic.AtomicInteger
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+
+@State(Scope.Thread)
+open class ReviewDeltaFlowBenchmark {
+    private lateinit var environment: BenchmarkEnvironment
+    private val coldCounter = AtomicInteger()
+
+    @Setup
+    fun setup() {
+        environment = BenchmarkEnvironment()
+        reviewDeltaFlow("flow-warm")
+    }
+
+    @TearDown
+    fun tearDown() {
+        environment.close()
+    }
+
+    @Benchmark
+    fun reviewDeltaFlowCold(): ReviewDeltaFlowResult = reviewDeltaFlow("flow-cold-${coldCounter.incrementAndGet()}")
+
+    @Benchmark
+    fun reviewDeltaFlowWarm(): ReviewDeltaFlowResult = reviewDeltaFlow("flow-warm")
+
+    private fun reviewDeltaFlow(suffix: String): ReviewDeltaFlowResult {
+        val baselineParams = environment.baselineReviewParams(suffix)
+        val currentParams = environment.currentReviewParams(suffix)
+        val baselineReview = ExtensionAPI.review(baselineParams, environment.cacheParams)
+        val currentReview = ExtensionAPI.review(currentParams, environment.cacheParams)
+        val delta = ExtensionAPI.delta(baselineParams, currentParams, environment.cacheParams)
+        return ReviewDeltaFlowResult(currentReview, baselineReview, delta)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ changelog = "2.5.0"
 ktlint = "14.0.1"
 intelliJPlatform = "2.11.0"
 kotlin = "1.9.25"
+jmh = "0.7.3"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -16,3 +17,4 @@ changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
 intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intelliJPlatform" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+jmh = { id = "me.champeau.jmh", version.ref = "jmh" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
 rootProject.name = "CodeScene"
 
 include(":core")
+include(":benchmarks")


### PR DESCRIPTION
## Summary
- Add a JMH benchmark module for real ExtensionAPI review, baseline review, delta, fn-to-refactor, and combined review/delta flows.
- Add a local `make benchmarks` target and GitHub workflow to publish JMH results through github-action-benchmark.

## Test plan
- `./gradlew.bat :benchmarks:jmh --stacktrace`
- `./gradlew.bat ktlintCheck core:ktlintCheck :benchmarks:ktlintCheck --console=plain -PktlintFailOnError=true`
- `./gradlew.bat check --console=plain -PktlintFailOnError=true`
- `make iter`
- CodeScene MCP pre-commit code health safeguard

Made with [Cursor](https://cursor.com)