### PR TITLE
fix: CS-6901: closest main-line merge base for baseline

### DIFF
--- a/.cursor/plans/fix_cs-6901_41bc957c.plan.md
+++ b/.cursor/plans/fix_cs-6901_41bc957c.plan.md
@@ -1,0 +1,68 @@
+---
+name: Fix CS-6901
+overview: Fix JetBrains baseline selection for stacked branches by selecting closest merge-base among all main-like refs. Keep behavior aligned with VS/VS Code fixes while preserving main-branch HEAD and reflog fallback semantics.
+todos:
+  - id: core-selector
+    content: Add core merge-base selector helper and unit tests.
+    status: pending
+  - id: platform-wire
+    content: Wire Git4IdeaGitService and Git4IdeaChangeLister to closest-baseline selection.
+    status: pending
+  - id: test-doubles
+    content: Update core test Git change listers to match new rule.
+    status: pending
+  - id: validate
+    content: Run Makefile validation and CodeScene MCP checks.
+    status: pending
+isProject: false
+---
+
+# Fix CS-6901 Baseline
+
+## Bug
+Current JetBrains code returns first successful main-like merge-base. Because `main` is checked before `develop`, feature branches stacked on `develop` can use old `main` ancestor as delta baseline.
+
+Key current code:
+
+```123:145:src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
+    private fun findMergeBaseWithMain(gitRepository: GitRepository): String? {
+        val currentBranchName = gitRepository.currentBranchName ?: return null
+        for (mainName in MAIN_BRANCH_NAMES) {
+            val refsToTry =
+                listOf(
+                    mainName,
+                    "origin/$mainName",
+                )
+            for (ref in refsToTry) {
+                // ...
+                if (!mergeBase.isNullOrBlank()) {
+                    return mergeBase.trim()
+                }
+            }
+        }
+        return null
+    }
+```
+
+Same first-hit logic exists in [src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt](src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt), affecting committed-file diff collection.
+
+## Approach
+- Add small core helper in [core/src/main/kotlin/com/codescene/jetbrains/core/git/](core/src/main/kotlin/com/codescene/jetbrains/core/git/) for shared main-branch refs and pure closest-merge-base selection.
+- Selection rule: collect unique merge-base SHAs for `main`, `origin/main`, `master`, `origin/master`, `develop`, `origin/develop`, etc.; choose candidate where every other candidate is ancestor of it. This matches VS Code PR #302 semantics.
+- Preserve existing behavior:
+  - on main-like branch, baseline remains `HEAD`
+  - if no merge-base, `Git4IdeaGitService` still falls back to reflog
+  - if closest selection cannot be resolved, fall back to first collected candidate
+- Extend [src/main/kotlin/com/codescene/jetbrains/platform/git/GitCommandExecutor.kt](src/main/kotlin/com/codescene/jetbrains/platform/git/GitCommandExecutor.kt) with `merge-base --is-ancestor` support so [Git4IdeaChangeLister.kt](src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt) can reuse same rule.
+- Refactor [Git4IdeaGitService.kt](src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt) to use same selector. I will keep IntelliJ Platform-specific command execution in platform code, with shared decision logic in `core`.
+
+## Tests
+- Add core unit tests for selector behavior: stacked `main -> develop -> feature`, duplicate merge-bases, no candidates, and unresolved sibling fallback.
+- Add platform regression in [src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerTest.kt](src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerTest.kt): stub `main` old SHA + `develop` newer SHA, assert `runDiff` uses newer SHA.
+- Add/adjust `Git4IdeaGitService` hash test if constructor refactor allows mock `GitCommandExecutor`; otherwise cover via core selector + change-lister path and keep service change minimal.
+- Update test doubles [core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeLister.kt](core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeLister.kt) and [TestGitChangeListerForCommitted.kt](core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeListerForCommitted.kt) so integration-style tests use same closest-baseline rule.
+
+## Validation
+- Run `make iter` with 10 minute timeout, per repo rule.
+- Run CodeScene MCP validation after edits: `code_health_review` on touched prod files and `pre_commit_code_health_safeguard` on repo.
+- Current CodeScene baseline checked: `Git4IdeaGitService.kt` score 10.0, `Git4IdeaChangeLister.kt` score 10.0; keep them green.

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/ClosestMainLineMergeBase.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/ClosestMainLineMergeBase.kt
@@ -1,0 +1,44 @@
+package com.codescene.jetbrains.core.git
+
+val MAIN_LINE_BRANCH_NAMES =
+    listOf("main", "master", "develop", "trunk", "dev", "development")
+
+fun mainLineRefsInProbeOrder(): List<String> = MAIN_LINE_BRANCH_NAMES.flatMap { listOf(it, "origin/$it") }
+
+fun collectOrderedUniqueMergeBases(mergeBaseForRef: (ref: String) -> String?): List<String> {
+    val ordered = mutableListOf<String>()
+    val seen = mutableSetOf<String>()
+    for (ref in mainLineRefsInProbeOrder()) {
+        val sha = mergeBaseForRef(ref)?.trim()?.takeIf { it.isNotEmpty() } ?: continue
+        if (seen.add(sha)) {
+            ordered.add(sha)
+        }
+    }
+    return ordered
+}
+
+fun selectClosestMergeBase(
+    orderedUniqueMergeBases: List<String>,
+    isAncestor: (ancestor: String, descendant: String) -> Boolean,
+): String? {
+    if (orderedUniqueMergeBases.isEmpty()) return null
+    if (orderedUniqueMergeBases.size == 1) return orderedUniqueMergeBases.first()
+    val winners =
+        orderedUniqueMergeBases.filter { candidate ->
+            orderedUniqueMergeBases.all { other ->
+                other == candidate || isAncestor(other, candidate)
+            }
+        }
+    return when (winners.size) {
+        1 -> winners.first()
+        else -> orderedUniqueMergeBases.first()
+    }
+}
+
+fun resolveClosestMainLineMergeBase(
+    isAncestor: (ancestor: String, descendant: String) -> Boolean,
+    mergeBaseForRef: (ref: String) -> String?,
+): String? {
+    val ordered = collectOrderedUniqueMergeBases(mergeBaseForRef)
+    return selectClosestMergeBase(ordered, isAncestor)
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/ClosestMainLineMergeBaseTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/ClosestMainLineMergeBaseTest.kt
@@ -1,0 +1,77 @@
+package com.codescene.jetbrains.core.git
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ClosestMainLineMergeBaseTest {
+    @Test
+    fun `resolveClosestMainLineMergeBase returns null when no merge base`() {
+        assertNull(
+            resolveClosestMainLineMergeBase(
+                isAncestor = { _, _ -> false },
+                mergeBaseForRef = { null },
+            ),
+        )
+    }
+
+    @Test
+    fun `selectClosestMergeBase returns single candidate`() {
+        assertEquals(
+            "only",
+            selectClosestMergeBase(listOf("only")) { _, _ -> false },
+        )
+    }
+
+    @Test
+    fun `selectClosestMergeBase picks descendant when chain is linear`() {
+        val ordered = listOf("old", "mid", "new")
+        val isAncestor: (String, String) -> Boolean = { a, d ->
+            when {
+                a == "old" && d == "mid" -> true
+                a == "old" && d == "new" -> true
+                a == "mid" && d == "new" -> true
+                else -> false
+            }
+        }
+        assertEquals("new", selectClosestMergeBase(ordered, isAncestor))
+    }
+
+    @Test
+    fun `selectClosestMergeBase falls back to first when candidates are incomparable`() {
+        val ordered = listOf("a", "b")
+        val isAncestor: (String, String) -> Boolean = { _, _ -> false }
+        assertEquals("a", selectClosestMergeBase(ordered, isAncestor))
+    }
+
+    @Test
+    fun `collectOrderedUniqueMergeBases preserves probe order and dedupes`() {
+        val seen = mutableListOf<String>()
+        val bases =
+            collectOrderedUniqueMergeBases { ref ->
+                seen.add(ref)
+                when (ref) {
+                    "main" -> "sha1"
+                    "origin/main" -> "sha1"
+                    "master" -> "sha2"
+                    else -> null
+                }
+            }
+        assertEquals(listOf("sha1", "sha2"), bases)
+        assertEquals("main", seen.first())
+        assertEquals("origin/main", seen[1])
+    }
+
+    @Test
+    fun `resolveClosestMainLineMergeBase picks newest among main and develop bases`() {
+        val mergeBases = mapOf("main" to "mainMb", "develop" to "developMb")
+        val result =
+            resolveClosestMainLineMergeBase(
+                isAncestor = { a, d ->
+                    a == "mainMb" && d == "developMb"
+                },
+                mergeBaseForRef = { ref -> mergeBases[ref] },
+            )
+        assertEquals("developMb", result)
+    }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeLister.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeLister.kt
@@ -145,21 +145,33 @@ class TestGitChangeLister(private val testRepoPath: File) : IGitChangeLister {
     private fun getMergeBase(gitRootPath: String): String? {
         val currentBranch = exec("git", "rev-parse", "--abbrev-ref", "HEAD").trim()
 
-        val mainBranchNames = listOf("main", "master", "develop", "trunk", "dev", "development")
-        if (mainBranchNames.any { it.equals(currentBranch, ignoreCase = true) }) {
+        if (MAIN_LINE_BRANCH_NAMES.any { it.equals(currentBranch, ignoreCase = true) }) {
             return exec("git", "rev-parse", "HEAD").trim()
         }
 
-        for (mainName in mainBranchNames) {
-            val refsToTry = listOf(mainName, "origin/$mainName")
-            for (ref in refsToTry) {
-                val output = exec("git", "merge-base", currentBranch, ref).trim()
-                if (output.isNotEmpty() && !output.startsWith("fatal")) {
-                    return output
-                }
-            }
-        }
+        return resolveClosestMainLineMergeBase(
+            isAncestor = { ancestor, descendant -> gitIsAncestor(ancestor, descendant) },
+            mergeBaseForRef = { ref -> gitMergeBaseWithRef(currentBranch, ref) },
+        )
+    }
 
-        return null
+    private fun gitMergeBaseWithRef(
+        currentBranch: String,
+        ref: String,
+    ): String? {
+        val output = exec("git", "merge-base", currentBranch, ref).trim()
+        return if (output.isNotEmpty() && !output.startsWith("fatal")) output else null
+    }
+
+    private fun gitIsAncestor(
+        ancestor: String,
+        descendant: String,
+    ): Boolean {
+        val process =
+            ProcessBuilder("git", "merge-base", "--is-ancestor", ancestor, descendant)
+                .directory(testRepoPath)
+                .redirectErrorStream(true)
+                .start()
+        return process.waitFor() == 0
     }
 }

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeListerForCommitted.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeListerForCommitted.kt
@@ -49,21 +49,33 @@ class TestGitChangeListerForCommitted(private val testRepoPath: File) : IGitChan
     private fun getMergeBase(gitRootPath: String): String? {
         val currentBranch = exec("git", "rev-parse", "--abbrev-ref", "HEAD").trim()
 
-        val mainBranchNames = listOf("main", "master", "develop", "trunk", "dev", "development")
-        if (mainBranchNames.any { it.equals(currentBranch, ignoreCase = true) }) {
+        if (MAIN_LINE_BRANCH_NAMES.any { it.equals(currentBranch, ignoreCase = true) }) {
             return exec("git", "rev-parse", "HEAD").trim()
         }
 
-        for (mainName in mainBranchNames) {
-            val refsToTry = listOf(mainName, "origin/$mainName")
-            for (ref in refsToTry) {
-                val output = exec("git", "merge-base", currentBranch, ref).trim()
-                if (output.isNotEmpty() && !output.startsWith("fatal")) {
-                    return output
-                }
-            }
-        }
+        return resolveClosestMainLineMergeBase(
+            isAncestor = { ancestor, descendant -> gitIsAncestor(ancestor, descendant) },
+            mergeBaseForRef = { ref -> gitMergeBaseWithRef(currentBranch, ref) },
+        )
+    }
 
-        return null
+    private fun gitMergeBaseWithRef(
+        currentBranch: String,
+        ref: String,
+    ): String? {
+        val output = exec("git", "merge-base", currentBranch, ref).trim()
+        return if (output.isNotEmpty() && !output.startsWith("fatal")) output else null
+    }
+
+    private fun gitIsAncestor(
+        ancestor: String,
+        descendant: String,
+    ): Boolean {
+        val process =
+            ProcessBuilder("git", "merge-base", "--is-ancestor", ancestor, descendant)
+                .directory(testRepoPath)
+                .redirectErrorStream(true)
+                .start()
+        return process.waitFor() == 0
     }
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt
@@ -3,10 +3,12 @@ package com.codescene.jetbrains.platform.git
 import com.codescene.jetbrains.core.contracts.IFileSystem
 import com.codescene.jetbrains.core.contracts.IGitChangeLister
 import com.codescene.jetbrains.core.git.FileSystemAdapter
+import com.codescene.jetbrains.core.git.MAIN_LINE_BRANCH_NAMES
 import com.codescene.jetbrains.core.git.MAX_UNTRACKED_FILES_PER_LOCATION
 import com.codescene.jetbrains.core.git.createWorkspacePrefix
 import com.codescene.jetbrains.core.git.pathComparisonKey
 import com.codescene.jetbrains.core.git.pathFileName
+import com.codescene.jetbrains.core.git.resolveClosestMainLineMergeBase
 import com.codescene.jetbrains.core.util.normalizeAbsolutePath
 import com.codescene.jetbrains.platform.util.Log
 import com.intellij.openapi.components.Service
@@ -18,8 +20,6 @@ import git4idea.repo.GitRepositoryManager
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-
-private val MAIN_BRANCH_NAMES = listOf("main", "master", "develop", "trunk", "dev", "development")
 
 private fun hasWindowsDriveLetter(path: String): Boolean = path.drop(1).startsWith(":/")
 
@@ -253,7 +253,7 @@ class Git4IdeaChangeLister
         }
 
         private fun isMainLineBranch(branchName: String): Boolean =
-            MAIN_BRANCH_NAMES.any { it.equals(branchName, ignoreCase = true) }
+            MAIN_LINE_BRANCH_NAMES.any { it.equals(branchName, ignoreCase = true) }
 
         private fun resolveHeadCommitSha(repository: GitRepository): String? = gitExecutor.runRevParse(repository)
 
@@ -261,25 +261,22 @@ class Git4IdeaChangeLister
             repository: GitRepository,
             currentBranchName: String,
         ): String? {
-            for (mainName in MAIN_BRANCH_NAMES) {
-                val refsToTry = listOf(mainName, "origin/$mainName")
-                for (ref in refsToTry) {
-                    val mergeBase = runMergeBase(repository, currentBranchName, ref)
-                    if (!mergeBase.isNullOrBlank()) {
-                        Log.info("Found merge base for ref=$ref", "Git4IdeaChangeLister")
-                        return mergeBase.trim()
-                    }
-                }
+            val resolved =
+                resolveClosestMainLineMergeBase(
+                    isAncestor = { ancestor, descendant ->
+                        gitExecutor.runIsAncestor(repository, ancestor, descendant)
+                    },
+                    mergeBaseForRef = { ref ->
+                        gitExecutor.runMergeBase(repository, currentBranchName, ref)
+                    },
+                )
+            if (resolved != null) {
+                Log.info("Resolved closest main-line merge base", "Git4IdeaChangeLister")
+            } else {
+                Log.info("Could not find merge base with any main branch", "Git4IdeaChangeLister")
             }
-            Log.info("Could not find merge base with any main branch", "Git4IdeaChangeLister")
-            return null
+            return resolved
         }
-
-        private fun runMergeBase(
-            repository: GitRepository,
-            rev1: String,
-            rev2: String,
-        ): String? = gitExecutor.runMergeBase(repository, rev1, rev2)
 
         private fun getRepository(gitRootPath: String): GitRepository? {
             val virtualFile = LocalFileSystem.getInstance().findFileByPath(gitRootPath) ?: return null

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaCommandExecutor.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaCommandExecutor.kt
@@ -48,4 +48,16 @@ class Git4IdeaCommandExecutor(private val project: Project) : GitCommandExecutor
             null
         }
     }
+
+    override fun runIsAncestor(
+        repository: GitRepository,
+        ancestor: String,
+        descendant: String,
+    ): Boolean {
+        val handler =
+            createGitLineHandler(project, repository.root, GitCommand.MERGE_BASE).apply {
+                addParameters("--is-ancestor", ancestor, descendant)
+            }
+        return Git.getInstance().runCommand(handler).success()
+    }
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
@@ -1,6 +1,8 @@
 package com.codescene.jetbrains.platform.git
 
 import com.codescene.jetbrains.core.contracts.IGitService
+import com.codescene.jetbrains.core.git.MAIN_LINE_BRANCH_NAMES
+import com.codescene.jetbrains.core.git.resolveClosestMainLineMergeBase
 import com.codescene.jetbrains.core.util.parseBranchCreationCommitFromReflog
 import com.codescene.jetbrains.platform.util.Log
 import com.intellij.dvcs.repo.Repository
@@ -18,6 +20,7 @@ import git4idea.repo.GitRepositoryManager
 @Service(Service.Level.PROJECT)
 class Git4IdeaGitService(val project: Project) : IGitService {
     private val service = "${this::class.java.simpleName} - ${project.name}"
+    private val gitCommandExecutor = Git4IdeaCommandExecutor(project)
 
     private data class RepositoryContext(
         val file: VirtualFile,
@@ -27,15 +30,12 @@ class Git4IdeaGitService(val project: Project) : IGitService {
 
     companion object {
         fun getInstance(project: Project): Git4IdeaGitService = project.service<Git4IdeaGitService>()
-
-        private val MAIN_BRANCH_NAMES =
-            listOf("main", "master", "develop", "trunk", "dev", "development")
     }
 
     /**
      * Resolves baseline file content for delta analysis, aligned with VS / VS Code:
      * - On a main-line branch (main, master, develop, trunk, dev): **HEAD** commit.
-     * - On a feature branch: **merge-base** with the first resolvable main-line ref (local name, then `origin/<name>`).
+     * - On a feature branch: **closest merge-base** among all resolvable main-line refs (same probe order as VS Code).
      * - Fallback: branch-creation commit from the current branch’s reflog (same as the previous JetBrains-only behavior).
      */
     override fun getBranchCreationCommitCode(filePath: String): String {
@@ -94,7 +94,7 @@ class Git4IdeaGitService(val project: Project) : IGitService {
     private fun getBaselineCommitSha(gitRepository: GitRepository): String? {
         val branchName = gitRepository.currentBranchName ?: return null
 
-        if (MAIN_BRANCH_NAMES.any { it.equals(branchName, ignoreCase = true) }) {
+        if (MAIN_LINE_BRANCH_NAMES.any { it.equals(branchName, ignoreCase = true) }) {
             return resolveHeadCommitSha(gitRepository)
         }
 
@@ -122,30 +122,14 @@ class Git4IdeaGitService(val project: Project) : IGitService {
 
     private fun findMergeBaseWithMain(gitRepository: GitRepository): String? {
         val currentBranchName = gitRepository.currentBranchName ?: return null
-        for (mainName in MAIN_BRANCH_NAMES) {
-            val refsToTry =
-                listOf(
-                    mainName,
-                    "origin/$mainName",
-                )
-            for (ref in refsToTry) {
-                val handler =
-                    createGitLineHandler(project, gitRepository.root, GitCommand.MERGE_BASE).apply {
-                        addParameters(currentBranchName, ref)
-                    }
-                val result = Git.getInstance().runCommand(handler)
-                val mergeBase =
-                    if (result.success()) {
-                        result.output.firstOrNull()?.trim()?.takeIf { it.isNotEmpty() }
-                    } else {
-                        null
-                    }
-                if (!mergeBase.isNullOrBlank()) {
-                    return mergeBase.trim()
-                }
-            }
-        }
-        return null
+        return resolveClosestMainLineMergeBase(
+            isAncestor = { ancestor, descendant ->
+                gitCommandExecutor.runIsAncestor(gitRepository, ancestor, descendant)
+            },
+            mergeBaseForRef = { ref ->
+                gitCommandExecutor.runMergeBase(gitRepository, currentBranchName, ref)
+            },
+        )
     }
 
     private fun getBranchCreationCommitFromReflog(gitRepository: GitRepository): String? =

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitCommandExecutor.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitCommandExecutor.kt
@@ -15,4 +15,10 @@ interface GitCommandExecutor {
         rev1: String,
         rev2: String,
     ): String?
+
+    fun runIsAncestor(
+        repository: GitRepository,
+        ancestor: String,
+        descendant: String,
+    ): Boolean
 }

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerFeatureBranchTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerFeatureBranchTest.kt
@@ -1,0 +1,180 @@
+package com.codescene.jetbrains.platform.git
+
+import com.codescene.jetbrains.core.util.normalizeAbsolutePath
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Git4IdeaChangeListerFeatureBranchTest : Git4IdeaChangeListerTestFixture() {
+    @Test
+    fun `getAllChangedFiles uses closest merge base when main and develop disagree`() =
+        runBlocking {
+            val workspace = "/test/repo"
+            val branch = "feature-stacked"
+
+            Git4IdeaTestSupport.setupRepositoryAccess(
+                mockLocalFileSystem,
+                mockRepoManager,
+                mockRepository,
+                mockVirtualFile,
+                gitRoot,
+            )
+            Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
+            Git4IdeaTestSupport.setupEmptyUntrackedFiles(mockRepository)
+            every { mockRepository.currentBranchName } returns branch
+            every { mockRepository.root } returns mockVirtualFile
+
+            every { mockGitExecutor.runMergeBase(mockRepository, branch, "main") } returns "oldMainMb"
+            every { mockGitExecutor.runMergeBase(mockRepository, branch, "develop") } returns "developMb"
+            every { mockGitExecutor.runIsAncestor(mockRepository, "oldMainMb", "developMb") } returns true
+            every { mockGitExecutor.runIsAncestor(mockRepository, "developMb", "oldMainMb") } returns false
+
+            every { mockGitExecutor.runDiff(mockRepository, "developMb") } returns listOf("stacked.ts")
+
+            Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, "stacked.ts", "ts")
+
+            git4IdeaChangeLister.getAllChangedFiles(gitRoot, workspace)
+
+            verify(exactly = 1) { mockGitExecutor.runDiff(mockRepository, "developMb") }
+        }
+
+    @Test
+    fun `getAllChangedFiles detects committed files via merge-base diff on feature branch`() =
+        runBlocking {
+            val workspace = "/test/repo"
+
+            Git4IdeaTestSupport.setupRepositoryAccess(
+                mockLocalFileSystem,
+                mockRepoManager,
+                mockRepository,
+                mockVirtualFile,
+                gitRoot,
+            )
+            Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
+            Git4IdeaTestSupport.setupEmptyUntrackedFiles(mockRepository)
+            Git4IdeaTestSupport.setupFeatureBranch(mockRepository, mockVirtualFile, mockGitExecutor)
+
+            every { mockGitExecutor.runDiff(mockRepository, "base123") } returns listOf("committed-only.ts")
+
+            Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, "committed-only.ts", "ts")
+
+            val changedFiles = git4IdeaChangeLister.getAllChangedFiles(gitRoot, workspace)
+
+            assertTrue(
+                "Should include committed file via merge-base diff",
+                changedFiles.any { it.endsWith("committed-only.ts") },
+            )
+        }
+
+    @Test
+    fun `getAllChangedFiles combines status and diff changes on feature branch`() =
+        runBlocking {
+            val workspace = "/test/repo"
+
+            Git4IdeaTestSupport.setupRepositoryAccess(
+                mockLocalFileSystem,
+                mockRepoManager,
+                mockRepository,
+                mockVirtualFile,
+                gitRoot,
+            )
+            Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
+            Git4IdeaTestSupport.setupFeatureBranch(mockRepository, mockVirtualFile, mockGitExecutor)
+
+            val untrackedFile = mockk<com.intellij.openapi.vcs.FilePath>()
+            every { untrackedFile.path } returns "uncommitted.ts"
+            every { mockRepository.untrackedFilesHolder.retrieveUntrackedFilePaths() } returns listOf(untrackedFile)
+
+            every { mockGitExecutor.runDiff(mockRepository, "base123") } returns listOf("committed.ts")
+
+            Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, "uncommitted.ts", "ts")
+            Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, "committed.ts", "ts")
+
+            val changedFiles = git4IdeaChangeLister.getAllChangedFiles(gitRoot, workspace)
+
+            val fileNames = changedFiles.map { File(it).name }
+            assertTrue("Should include uncommitted file", fileNames.contains("uncommitted.ts"))
+            assertTrue("Should include committed file", fileNames.contains("committed.ts"))
+        }
+
+    @Test
+    fun `getAllChangedFiles respects filesToExcludeFromHeuristic for untracked files`() =
+        runBlocking {
+            val workspace = "/test/repo"
+
+            Git4IdeaTestSupport.setupRepositoryAccess(
+                mockLocalFileSystem,
+                mockRepoManager,
+                mockRepository,
+                mockVirtualFile,
+                gitRoot,
+            )
+            Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
+            every { mockRepository.currentBranchName } returns "master"
+            every { mockGitExecutor.runRevParse(mockRepository) } returns "abc123"
+
+            val files =
+                (1..10).map { i ->
+                    val file = mockk<com.intellij.openapi.vcs.FilePath>()
+                    every { file.path } returns "untracked$i.ts"
+                    file
+                }
+            every { mockRepository.untrackedFilesHolder.retrieveUntrackedFilePaths() } returns files
+
+            files.forEach { file ->
+                val fileName = file.path
+                Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, fileName, "ts")
+                every { mockFileSystem.getParent(fileName) } returns null
+            }
+
+            val file2Path = "$gitRoot/untracked2.ts"
+            val file5Path = "$gitRoot/untracked5.ts"
+            val filesToExcludeFromHeuristic = setOf(file2Path, file5Path)
+
+            val changedFiles =
+                git4IdeaChangeLister.getAllChangedFiles(
+                    gitRoot,
+                    workspace,
+                    filesToExcludeFromHeuristic,
+                )
+
+            val fileNames = changedFiles.map { File(it).name }
+            assertTrue("Should include untracked2.ts", fileNames.contains("untracked2.ts"))
+            assertTrue("Should include untracked5.ts", fileNames.contains("untracked5.ts"))
+        }
+
+    @Test
+    fun `getAllChangedFiles handles untracked files with absolute paths`() =
+        runBlocking {
+            Git4IdeaTestSupport.setupRepositoryAccess(
+                mockLocalFileSystem,
+                mockRepoManager,
+                mockRepository,
+                mockVirtualFile,
+                gitRoot,
+            )
+            Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
+            every { mockRepository.currentBranchName } returns "master"
+            every { mockGitExecutor.runRevParse(mockRepository) } returns "abc123"
+
+            val untrackedFile = mockk<com.intellij.openapi.vcs.FilePath>()
+            every { untrackedFile.path } returns "$gitRoot/test.ts"
+            every { mockRepository.untrackedFilesHolder.retrieveUntrackedFilePaths() } returns listOf(untrackedFile)
+
+            val absolutePath = normalizeAbsolutePath("$gitRoot/test.ts")
+            every { mockFileSystem.getAbsolutePath(gitRoot, "$gitRoot/test.ts") } returns "$gitRoot/test.ts"
+            every { mockFileSystem.fileExists(absolutePath) } returns true
+            every { mockFileSystem.getExtension(absolutePath) } returns "ts"
+            every { mockFileSystem.getParent("$gitRoot/test.ts") } returns gitRoot
+            every { mockFileSystem.getRelativePath(gitRoot, absolutePath) } returns "test.ts"
+
+            val changedFiles = git4IdeaChangeLister.getAllChangedFiles(gitRoot, gitRoot)
+
+            assertTrue("Should find untracked file with absolute path", changedFiles.isNotEmpty())
+            assertTrue("Should resolve absolute path correctly", changedFiles.any { it.endsWith("test.ts") })
+        }
+}

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerTest.kt
@@ -1,70 +1,15 @@
 package com.codescene.jetbrains.platform.git
 
-import com.codescene.jetbrains.core.contracts.IFileSystem
-import com.codescene.jetbrains.core.util.normalizeAbsolutePath
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.VirtualFile
-import git4idea.ignore.GitRepositoryIgnoredFilesHolder
 import git4idea.index.GitFileStatus
-import git4idea.repo.GitRepository
-import git4idea.repo.GitRepositoryManager
-import git4idea.status.GitStagingAreaHolder
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-import java.io.File
 import kotlinx.coroutines.runBlocking
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 
-class Git4IdeaChangeListerTest {
-    private val gitRoot = "/test/repo"
-    private lateinit var project: Project
-    private lateinit var git4IdeaChangeLister: Git4IdeaChangeLister
-    private lateinit var mockRepository: GitRepository
-    private lateinit var mockRepoManager: GitRepositoryManager
-    private lateinit var mockLocalFileSystem: LocalFileSystem
-    private lateinit var mockVirtualFile: VirtualFile
-    private lateinit var mockStagingArea: GitStagingAreaHolder
-    private lateinit var mockFileSystem: IFileSystem
-    private lateinit var mockGitExecutor: GitCommandExecutor
-    private lateinit var mockIgnoredFilesHolder: GitRepositoryIgnoredFilesHolder
-
-    @Before
-    fun setup() {
-        project = mockk(relaxed = true)
-        mockRepository = mockk(relaxed = true)
-        mockRepoManager = mockk(relaxed = true)
-        mockLocalFileSystem = mockk(relaxed = true)
-        mockVirtualFile = mockk(relaxed = true)
-        mockStagingArea = mockk(relaxed = true)
-        mockFileSystem = mockk(relaxed = true)
-        mockGitExecutor = mockk(relaxed = true)
-        mockIgnoredFilesHolder = mockk(relaxed = true)
-
-        every { mockRepository.ignoredFilesHolder } returns mockIgnoredFilesHolder
-        every { mockIgnoredFilesHolder.containsFile(any()) } returns false
-
-        mockkStatic(GitRepositoryManager::class)
-        every { GitRepositoryManager.getInstance(project) } returns mockRepoManager
-
-        mockkStatic(LocalFileSystem::class)
-        every { LocalFileSystem.getInstance() } returns mockLocalFileSystem
-
-        git4IdeaChangeLister = Git4IdeaChangeLister(project, mockFileSystem, mockGitExecutor)
-    }
-
-    @After
-    fun teardown() {
-        unmockkAll()
-    }
-
+class Git4IdeaChangeListerTest : Git4IdeaChangeListerTestFixture() {
     @Test
     fun `getAllChangedFiles returns empty set when repository is null`() =
         runBlocking {
@@ -151,7 +96,7 @@ class Git4IdeaChangeListerTest {
     @Test
     fun `getAllChangedFiles filters unsupported file types`() =
         runBlocking {
-            val gitRoot = "/test/repo"
+            val localGitRoot = "/test/repo"
             val workspace = "/test/repo"
 
             Git4IdeaTestSupport.setupRepositoryAccess(
@@ -159,7 +104,7 @@ class Git4IdeaChangeListerTest {
                 mockRepoManager,
                 mockRepository,
                 mockVirtualFile,
-                gitRoot,
+                localGitRoot,
             )
             Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
             every { mockRepository.currentBranchName } returns "master"
@@ -172,153 +117,13 @@ class Git4IdeaChangeListerTest {
 
             every { mockRepository.untrackedFilesHolder.retrieveUntrackedFilePaths() } returns listOf(txtFile, tsFile)
 
-            Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, "notes.txt", "txt")
-            Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, "code.ts", "ts")
+            Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, localGitRoot, workspace, "notes.txt", "txt")
+            Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, localGitRoot, workspace, "code.ts", "ts")
 
-            val changedFiles = git4IdeaChangeLister.getAllChangedFiles(gitRoot, workspace)
+            val changedFiles = git4IdeaChangeLister.getAllChangedFiles(localGitRoot, workspace)
 
             assertEquals(1, changedFiles.size)
             assertTrue(changedFiles.any { it.endsWith("code.ts") })
             assertFalse(changedFiles.any { it.endsWith("notes.txt") })
-        }
-
-    @Test
-    fun `getAllChangedFiles detects committed files via merge-base diff on feature branch`() =
-        runBlocking {
-            val gitRoot = "/test/repo"
-            val workspace = "/test/repo"
-
-            Git4IdeaTestSupport.setupRepositoryAccess(
-                mockLocalFileSystem,
-                mockRepoManager,
-                mockRepository,
-                mockVirtualFile,
-                gitRoot,
-            )
-            Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
-            Git4IdeaTestSupport.setupEmptyUntrackedFiles(mockRepository)
-            Git4IdeaTestSupport.setupFeatureBranch(mockRepository, mockVirtualFile, mockGitExecutor)
-
-            every { mockGitExecutor.runDiff(mockRepository, "base123") } returns listOf("committed-only.ts")
-
-            Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, "committed-only.ts", "ts")
-
-            val changedFiles = git4IdeaChangeLister.getAllChangedFiles(gitRoot, workspace)
-
-            assertTrue(
-                "Should include committed file via merge-base diff",
-                changedFiles.any { it.endsWith("committed-only.ts") },
-            )
-        }
-
-    @Test
-    fun `getAllChangedFiles combines status and diff changes on feature branch`() =
-        runBlocking {
-            val gitRoot = "/test/repo"
-            val workspace = "/test/repo"
-
-            Git4IdeaTestSupport.setupRepositoryAccess(
-                mockLocalFileSystem,
-                mockRepoManager,
-                mockRepository,
-                mockVirtualFile,
-                gitRoot,
-            )
-            Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
-            Git4IdeaTestSupport.setupFeatureBranch(mockRepository, mockVirtualFile, mockGitExecutor)
-
-            val untrackedFile = mockk<com.intellij.openapi.vcs.FilePath>()
-            every { untrackedFile.path } returns "uncommitted.ts"
-            every { mockRepository.untrackedFilesHolder.retrieveUntrackedFilePaths() } returns listOf(untrackedFile)
-
-            every { mockGitExecutor.runDiff(mockRepository, "base123") } returns listOf("committed.ts")
-
-            Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, "uncommitted.ts", "ts")
-            Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, "committed.ts", "ts")
-
-            val changedFiles = git4IdeaChangeLister.getAllChangedFiles(gitRoot, workspace)
-
-            val fileNames = changedFiles.map { File(it).name }
-            assertTrue("Should include uncommitted file", fileNames.contains("uncommitted.ts"))
-            assertTrue("Should include committed file", fileNames.contains("committed.ts"))
-        }
-
-    @Test
-    fun `getAllChangedFiles respects filesToExcludeFromHeuristic for untracked files`() =
-        runBlocking {
-            val gitRoot = "/test/repo"
-            val workspace = "/test/repo"
-
-            Git4IdeaTestSupport.setupRepositoryAccess(
-                mockLocalFileSystem,
-                mockRepoManager,
-                mockRepository,
-                mockVirtualFile,
-                gitRoot,
-            )
-            Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
-            every { mockRepository.currentBranchName } returns "master"
-            every { mockGitExecutor.runRevParse(mockRepository) } returns "abc123"
-
-            val files =
-                (1..10).map { i ->
-                    val file = mockk<com.intellij.openapi.vcs.FilePath>()
-                    every { file.path } returns "untracked$i.ts"
-                    file
-                }
-            every { mockRepository.untrackedFilesHolder.retrieveUntrackedFilePaths() } returns files
-
-            files.forEach { file ->
-                val fileName = file.path
-                Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, fileName, "ts")
-                every { mockFileSystem.getParent(fileName) } returns null
-            }
-
-            val file2Path = "$gitRoot/untracked2.ts"
-            val file5Path = "$gitRoot/untracked5.ts"
-            val filesToExcludeFromHeuristic = setOf(file2Path, file5Path)
-
-            val changedFiles =
-                git4IdeaChangeLister.getAllChangedFiles(
-                    gitRoot,
-                    workspace,
-                    filesToExcludeFromHeuristic,
-                )
-
-            val fileNames = changedFiles.map { File(it).name }
-            assertTrue("Should include untracked2.ts", fileNames.contains("untracked2.ts"))
-            assertTrue("Should include untracked5.ts", fileNames.contains("untracked5.ts"))
-        }
-
-    @Test
-    fun `getAllChangedFiles handles untracked files with absolute paths`() =
-        runBlocking {
-            val gitRoot = "/test/repo"
-            Git4IdeaTestSupport.setupRepositoryAccess(
-                mockLocalFileSystem,
-                mockRepoManager,
-                mockRepository,
-                mockVirtualFile,
-                gitRoot,
-            )
-            Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
-            every { mockRepository.currentBranchName } returns "master"
-            every { mockGitExecutor.runRevParse(mockRepository) } returns "abc123"
-
-            val untrackedFile = mockk<com.intellij.openapi.vcs.FilePath>()
-            every { untrackedFile.path } returns "$gitRoot/test.ts"
-            every { mockRepository.untrackedFilesHolder.retrieveUntrackedFilePaths() } returns listOf(untrackedFile)
-
-            val absolutePath = normalizeAbsolutePath("$gitRoot/test.ts")
-            every { mockFileSystem.getAbsolutePath(gitRoot, "$gitRoot/test.ts") } returns "$gitRoot/test.ts"
-            every { mockFileSystem.fileExists(absolutePath) } returns true
-            every { mockFileSystem.getExtension(absolutePath) } returns "ts"
-            every { mockFileSystem.getParent("$gitRoot/test.ts") } returns gitRoot
-            every { mockFileSystem.getRelativePath(gitRoot, absolutePath) } returns "test.ts"
-
-            val changedFiles = git4IdeaChangeLister.getAllChangedFiles(gitRoot, gitRoot)
-
-            assertTrue("Should find untracked file with absolute path", changedFiles.isNotEmpty())
-            assertTrue("Should resolve absolute path correctly", changedFiles.any { it.endsWith("test.ts") })
         }
 }

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerTestFixture.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerTestFixture.kt
@@ -1,0 +1,59 @@
+package com.codescene.jetbrains.platform.git
+
+import com.codescene.jetbrains.core.contracts.IFileSystem
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import git4idea.ignore.GitRepositoryIgnoredFilesHolder
+import git4idea.repo.GitRepository
+import git4idea.repo.GitRepositoryManager
+import git4idea.status.GitStagingAreaHolder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Before
+
+abstract class Git4IdeaChangeListerTestFixture {
+    protected val gitRoot = "/test/repo"
+    protected lateinit var project: Project
+    protected lateinit var git4IdeaChangeLister: Git4IdeaChangeLister
+    protected lateinit var mockRepository: GitRepository
+    protected lateinit var mockRepoManager: GitRepositoryManager
+    protected lateinit var mockLocalFileSystem: LocalFileSystem
+    protected lateinit var mockVirtualFile: VirtualFile
+    protected lateinit var mockStagingArea: GitStagingAreaHolder
+    protected lateinit var mockFileSystem: IFileSystem
+    protected lateinit var mockGitExecutor: GitCommandExecutor
+    protected lateinit var mockIgnoredFilesHolder: GitRepositoryIgnoredFilesHolder
+
+    @Before
+    open fun setup() {
+        project = mockk(relaxed = true)
+        mockRepository = mockk(relaxed = true)
+        mockRepoManager = mockk(relaxed = true)
+        mockLocalFileSystem = mockk(relaxed = true)
+        mockVirtualFile = mockk(relaxed = true)
+        mockStagingArea = mockk(relaxed = true)
+        mockFileSystem = mockk(relaxed = true)
+        mockGitExecutor = mockk(relaxed = true)
+        mockIgnoredFilesHolder = mockk(relaxed = true)
+
+        every { mockRepository.ignoredFilesHolder } returns mockIgnoredFilesHolder
+        every { mockIgnoredFilesHolder.containsFile(any()) } returns false
+
+        mockkStatic(GitRepositoryManager::class)
+        every { GitRepositoryManager.getInstance(project) } returns mockRepoManager
+
+        mockkStatic(LocalFileSystem::class)
+        every { LocalFileSystem.getInstance() } returns mockLocalFileSystem
+
+        git4IdeaChangeLister = Git4IdeaChangeLister(project, mockFileSystem, mockGitExecutor)
+    }
+
+    @After
+    open fun teardown() {
+        unmockkAll()
+    }
+}


### PR DESCRIPTION
## Summary
Select the **closest** merge-base among probed main-line refs (VS Code–aligned) so stacked branches on \develop\ do not use an old \main\ merge-base.

## Changes
- Core: \ClosestMainLineMergeBase\ + unit tests
- Platform: \Git4IdeaGitService\, \Git4IdeaChangeLister\, \GitCommandExecutor.runIsAncestor\
- Test doubles: \TestGitChangeLister\, \TestGitChangeListerForCommitted\
- Split \Git4IdeaChangeListerTest\ for class-size limit