### PR TITLE
Fix read-action violation when opening docs from CEF webview

### DIFF
--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/OpenDocs.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/OpenDocs.kt
@@ -21,6 +21,7 @@ import com.codescene.jetbrains.platform.util.Log
 import com.codescene.jetbrains.platform.util.getSelectedTextEditor
 import com.codescene.jetbrains.platform.webview.WebViewInitializer
 import com.codescene.jetbrains.platform.webview.handler.CwfMessageHandler
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
@@ -87,8 +88,13 @@ internal fun resolveFnToRefactorForDocumentation(
         preferredDocumentText
             ?: run {
                 val virtualFile = LocalFileSystem.getInstance().findFileByPath(filePath)
-                val document = virtualFile?.let { FileDocumentManager.getInstance().getDocument(it) }
-                document?.text
+                val fromDocument =
+                    virtualFile?.let { vf ->
+                        runReadAction<String?> {
+                            FileDocumentManager.getInstance().getDocument(vf)?.text
+                        }
+                    }
+                fromDocument
                     ?: runCatching { services.fileSystem.readFile(filePath) }
                         .getOrElse { t ->
                             val kind = t.javaClass.simpleName


### PR DESCRIPTION
## Summary
- Wrap `FileDocumentManager.getDocument` in `runReadAction` inside `resolveFnToRefactorForDocumentation`, matching the existing ACE handler pattern.
- Fixes `RuntimeExceptionWithAttachments` when opening docs from the Code Health Details webview (`OpenDocsForFunction` on the CEF handler thread).

## Test plan
- [ ] From Code Health Details webview, open docs for a function in a file open in the IDE — no threading exception; docs panel opens.
- [ ] Open docs via Code Vision / intention action — still works (uses `editor.document.text`).
- [ ] Request refactoring from Code Health Details — unchanged (already uses `runReadAction` in ACE handler).
