### PR TITLE
Restore dynamic plugin install

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,5 +1,5 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
-<idea-plugin require-restart="true">
+<idea-plugin>
     <id>com.codescene.vanilla</id>
     <name>CodeScene</name>
     <vendor>CodeScene</vendor>

--- a/src/test/kotlin/com/codescene/jetbrains/platform/PluginDescriptorTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/PluginDescriptorTest.kt
@@ -1,0 +1,27 @@
+package com.codescene.jetbrains.platform
+
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class PluginDescriptorTest {
+    @Test
+    fun `plugin descriptor does not require restart`() {
+        val descriptor =
+            javaClass.classLoader.getResourceAsStream("META-INF/plugin.xml")
+                ?: error("META-INF/plugin.xml not found")
+
+        val root =
+            descriptor.use {
+                DocumentBuilderFactory
+                    .newInstance()
+                    .newDocumentBuilder()
+                    .parse(it)
+                    .documentElement
+            }
+
+        assertEquals("idea-plugin", root.tagName)
+        assertFalse(root.hasAttribute("require-restart"))
+    }
+}


### PR DESCRIPTION
## Summary
- Remove the explicit equire-restart attribute so the plugin can be dynamically installed again.
- Add a descriptor regression test to keep the restart requirement from returning.

## Test plan
- make iter NULL=NUL
- CodeScene MCP code_health_review on PluginDescriptorTest.kt: 10.0
- CodeScene MCP nalyze_change_set against master: passed