### PR TITLE
Fix flaky refactorable-fn in Code Health Monitor

### DIFF
--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -49,7 +49,20 @@
                     "weight": 0.0
                 }
             ],
-            "thresholds": [ ]
+            "thresholds": [
+                {
+                    "name": "function_max_arguments",
+                    "value": 5
+                },
+                {
+                    "name": "function_lines_of_code_warning",
+                    "value": 100
+                },
+                {
+                    "name": "function_lines_of_code_alert",
+                    "value": 200
+                }
+             ]
         }
     ]
 }

--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -52,7 +52,7 @@
             "thresholds": [
                 {
                     "name": "function_max_arguments",
-                    "value": 5
+                    "value": 6
                 },
                 {
                     "name": "function_lines_of_code_warning",

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/review/AceRefactorableFunctionsCacheService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/review/AceRefactorableFunctionsCacheService.kt
@@ -3,6 +3,7 @@ package com.codescene.jetbrains.core.review
 import com.codescene.data.ace.FnToRefactor
 import com.codescene.jetbrains.core.contracts.IAceRefactorableFunctionsCache
 import com.codescene.jetbrains.core.contracts.ILogger
+import com.codescene.jetbrains.core.git.pathCacheKey
 import com.codescene.jetbrains.core.util.isSha256Hex
 import org.apache.commons.codec.digest.DigestUtils
 
@@ -35,21 +36,23 @@ open class AceRefactorableFunctionsCacheService(
         val (filePath, content) = query
         val code = if (isSha256Hex(content)) content else DigestUtils.sha256Hex(content)
 
-        cache[filePath]?.let {
+        cache[key(filePath)]?.let {
             if (it.content == code) return it.result
         }
 
         return emptyList()
     }
 
-    override fun getLastKnown(filePath: String): List<FnToRefactor> = cache[filePath]?.result.orEmpty()
+    override fun getLastKnown(filePath: String): List<FnToRefactor> = cache[key(filePath)]?.result.orEmpty()
 
     override fun put(entry: AceRefactorableFunctionCacheEntry) {
         val (filePath, content, result) = entry
         val code = DigestUtils.sha256Hex(content)
 
-        cache[filePath] = AceRefactorableFunctionCacheItem(code, result)
+        cache[key(filePath)] = AceRefactorableFunctionCacheItem(code, result)
     }
+
+    override fun key(filePath: String): String = pathCacheKey(filePath)
 
     override fun get(
         filePath: String,

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/util/FunctionToRefactorUtils.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/util/FunctionToRefactorUtils.kt
@@ -1,8 +1,21 @@
 package com.codescene.jetbrains.core.util
 
 import com.codescene.data.ace.FnToRefactor
+import com.codescene.jetbrains.core.contracts.IAceRefactorableFunctionsCache
+import com.codescene.jetbrains.core.git.pathCacheKey
 import com.codescene.jetbrains.core.models.view.FunctionToRefactor
 import com.codescene.jetbrains.core.models.view.RefactoringTarget
+
+fun resolveAceCandidatesForMonitor(
+    cache: IAceRefactorableFunctionsCache,
+    filePath: String,
+    contentSha: String,
+): List<FnToRefactor> {
+    val key = pathCacheKey(filePath)
+    val fresh = cache.get(key, contentSha)
+    if (fresh.isNotEmpty()) return fresh
+    return cache.getLastKnown(key)
+}
 
 fun resolveFunctionToRefactor(
     candidates: List<FnToRefactor>,

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/mapper/CodeHealthMonitorMapperTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/mapper/CodeHealthMonitorMapperTest.kt
@@ -8,6 +8,7 @@ import com.codescene.jetbrains.core.models.CwfMessage
 import com.codescene.jetbrains.core.models.View
 import com.codescene.jetbrains.core.models.shared.AutoRefactorConfig
 import com.codescene.jetbrains.core.models.view.FunctionToRefactor
+import com.codescene.jetbrains.core.models.view.RefactoringTarget
 import com.codescene.jetbrains.core.util.Constants.DELTA_ANALYSIS_JOB
 import com.codescene.jetbrains.core.util.Constants.JOB_STATE_RUNNING
 import io.mockk.every
@@ -15,6 +16,7 @@ import io.mockk.mockk
 import java.util.Optional
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -160,6 +162,47 @@ class CodeHealthMonitorMapperTest {
     fun `toCwfData maps null file level findings to empty list`() {
         val delta = createDelta(fileLevelFindings = null)
         assertTrue(singleFileDelta(delta).delta.fileLevelFindings.isEmpty())
+    }
+
+    @Test
+    fun `toCwfData maps refactorable-fn when resolver returns match`() {
+        val range = mockk<com.codescene.data.delta.Range>(relaxed = true)
+        every { range.startLine } returns 1
+        every { range.endLine } returns 10
+
+        val function = mockk<com.codescene.data.delta.Function>(relaxed = true)
+        every { function.name } returns "myFn"
+        every { function.range } returns Optional.of(range)
+
+        val fnFinding = mockk<DeltaFunctionFinding>(relaxed = true)
+        every { fnFinding.function } returns function
+        every { fnFinding.changeDetails } returns emptyList()
+
+        val delta = createDelta(scoreChange = 1.0, functionLevelFindings = listOf(fnFinding))
+        val refactorable =
+            FunctionToRefactor(
+                body = "fun myFn() {}",
+                name = "myFn",
+                fileType = "kotlin",
+                functionType = "function",
+                refactoringTargets = listOf(RefactoringTarget(line = 1, category = "Complex Method")),
+            )
+        val resolver: (String, String, DeltaFunctionFinding) -> FunctionToRefactor? = { _, _, _ -> refactorable }
+
+        val fileDelta =
+            mapper
+                .toCwfData(
+                    deltaResults = listOf("file.kt" to createCacheItem(delta)),
+                    activeJobs = emptyList(),
+                    functionToRefactorResolver = resolver,
+                    autoRefactorConfig = autoRefactorConfig,
+                    devmode = false,
+                )
+                .data!!
+                .fileDeltaData[0]
+
+        assertNotNull(fileDelta.delta.functionLevelFindings[0].functionToRefactor)
+        assertEquals("myFn", fileDelta.delta.functionLevelFindings[0].functionToRefactor!!.name)
     }
 
     @Test

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/AceRefactorableFunctionsCacheServiceTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/AceRefactorableFunctionsCacheServiceTest.kt
@@ -129,4 +129,11 @@ class AceRefactorableFunctionsCacheServiceTest {
         val result = cache.get(query)
         assertEquals(1, result.size)
     }
+
+    @Test
+    fun `put and get normalize file path with pathCacheKey`() {
+        cache.put("C:\\repo\\file.kt", "content", listOf(createFn("fn1")))
+        assertEquals(1, cache.get("c:/repo/file.kt", "content").size)
+        assertEquals(1, cache.getLastKnown("C:\\repo\\file.kt").size)
+    }
 }

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/InMemoryAceRefactorableFunctionsCache.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/InMemoryAceRefactorableFunctionsCache.kt
@@ -2,6 +2,7 @@ package com.codescene.jetbrains.core.testdoubles
 
 import com.codescene.data.ace.FnToRefactor
 import com.codescene.jetbrains.core.contracts.IAceRefactorableFunctionsCache
+import com.codescene.jetbrains.core.git.pathCacheKey
 import com.codescene.jetbrains.core.util.isSha256Hex
 import org.apache.commons.codec.digest.DigestUtils
 
@@ -13,21 +14,21 @@ class InMemoryAceRefactorableFunctionsCache : IAceRefactorableFunctionsCache {
         content: String,
     ): List<FnToRefactor> {
         val contentHash = if (isSha256Hex(content)) content else DigestUtils.sha256Hex(content)
-        return cache[filePath]?.takeIf { it.contentHash == contentHash }?.result.orEmpty()
+        return cache[pathCacheKey(filePath)]?.takeIf { it.contentHash == contentHash }?.result.orEmpty()
     }
 
-    override fun getLastKnown(filePath: String): List<FnToRefactor> = cache[filePath]?.result.orEmpty()
+    override fun getLastKnown(filePath: String): List<FnToRefactor> = cache[pathCacheKey(filePath)]?.result.orEmpty()
 
     override fun put(
         filePath: String,
         content: String,
         result: List<FnToRefactor>,
     ) {
-        cache[filePath] = CacheItem(DigestUtils.sha256Hex(content), result)
+        cache[pathCacheKey(filePath)] = CacheItem(DigestUtils.sha256Hex(content), result)
     }
 
     override fun invalidate(filePath: String) {
-        cache.remove(filePath)
+        cache.remove(pathCacheKey(filePath))
     }
 
     private data class CacheItem(

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/util/FunctionToRefactorUtilsTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/util/FunctionToRefactorUtilsTest.kt
@@ -4,12 +4,15 @@ import com.codescene.data.ace.FnToRefactor
 import com.codescene.data.ace.RefactoringTarget as AceRefactoringTarget
 import com.codescene.data.delta.Function
 import com.codescene.data.delta.FunctionFinding
+import com.codescene.jetbrains.core.testdoubles.InMemoryAceRefactorableFunctionsCache
 import io.mockk.every
 import io.mockk.mockk
 import java.util.Optional
+import org.apache.commons.codec.digest.DigestUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FunctionToRefactorUtilsTest {
@@ -94,6 +97,32 @@ class FunctionToRefactorUtilsTest {
     fun `resolveFunctionToRefactor returns null for empty candidates`() {
         val finding = createFunctionFinding(name = "myFn")
         assertNull(resolveFunctionToRefactor(emptyList(), finding))
+    }
+
+    @Test
+    fun `resolveAceCandidatesForMonitor returns fresh match by content sha`() {
+        val cache = InMemoryAceRefactorableFunctionsCache()
+        cache.put("a.kt", "content", listOf(createFnToRefactor(name = "fn1")))
+        val sha = DigestUtils.sha256Hex("content")
+        val result = resolveAceCandidatesForMonitor(cache, "a.kt", sha)
+        assertEquals(1, result.size)
+        assertEquals("fn1", result[0].name)
+    }
+
+    @Test
+    fun `resolveAceCandidatesForMonitor returns stale when content sha mismatches`() {
+        val cache = InMemoryAceRefactorableFunctionsCache()
+        cache.put("a.kt", "content", listOf(createFnToRefactor(name = "fn1")))
+        val staleSha = DigestUtils.sha256Hex("different content")
+        val result = resolveAceCandidatesForMonitor(cache, "a.kt", staleSha)
+        assertEquals(1, result.size)
+        assertEquals("fn1", result[0].name)
+    }
+
+    @Test
+    fun `resolveAceCandidatesForMonitor returns empty when no cache entry`() {
+        val cache = InMemoryAceRefactorableFunctionsCache()
+        assertTrue(resolveAceCandidatesForMonitor(cache, "a.kt", DigestUtils.sha256Hex("x")).isEmpty())
     }
 
     @Test

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
@@ -16,10 +16,10 @@ import com.codescene.jetbrains.core.review.BaseService
 import com.codescene.jetbrains.core.review.RefactorableFunctionsOrchestrator
 import com.codescene.jetbrains.core.util.Constants.ACE
 import com.codescene.jetbrains.core.util.TelemetryEvents
+import com.codescene.jetbrains.core.util.normalizeAbsolutePath
 import com.codescene.jetbrains.platform.di.CodeSceneApplicationServiceProvider
 import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
 import com.codescene.jetbrains.platform.telemetry.StatsCollectorService
-import com.codescene.jetbrains.core.util.normalizeAbsolutePath
 import com.codescene.jetbrains.platform.util.AceEntryOrchestrator
 import com.codescene.jetbrains.platform.util.Log
 import com.codescene.jetbrains.platform.util.RefactoringParams

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
@@ -19,13 +19,16 @@ import com.codescene.jetbrains.core.util.TelemetryEvents
 import com.codescene.jetbrains.platform.di.CodeSceneApplicationServiceProvider
 import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
 import com.codescene.jetbrains.platform.telemetry.StatsCollectorService
+import com.codescene.jetbrains.core.util.normalizeAbsolutePath
 import com.codescene.jetbrains.platform.util.AceEntryOrchestrator
 import com.codescene.jetbrains.platform.util.Log
 import com.codescene.jetbrains.platform.util.RefactoringParams
+import com.codescene.jetbrains.platform.webview.util.updateMonitor
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -75,6 +78,24 @@ class AceService :
     }
 
     suspend fun getRefactorableFunctions(
+        project: Project,
+        filePath: String,
+        currentCode: String,
+        params: CodeParams,
+        cacheParams: CacheParams,
+        review: Review,
+    ): Boolean {
+        val codeSmells = review.fileLevelCodeSmells + review.functionLevelCodeSmells.flatMap { it.codeSmells }
+        Log.debug(
+            "Getting refactorable functions for $filePath based on review with $codeSmells...",
+            serviceImplementation,
+        )
+        return refactorableFunctionsHandler(project, filePath, currentCode) {
+            ExtensionAPI.fnToRefactor(params, cacheParams, codeSmells)
+        }
+    }
+
+    suspend fun getRefactorableFunctions(
         params: CodeParams,
         cacheParams: CacheParams,
         delta: Delta,
@@ -85,6 +106,23 @@ class AceService :
             serviceImplementation,
         )
         return refactorableFunctionsHandler(editor) { ExtensionAPI.fnToRefactor(params, cacheParams, delta) }
+    }
+
+    suspend fun getRefactorableFunctions(
+        project: Project,
+        filePath: String,
+        currentCode: String,
+        params: CodeParams,
+        cacheParams: CacheParams,
+        delta: Delta,
+    ): Boolean {
+        Log.debug(
+            "Getting refactorable functions for $filePath based on delta...",
+            serviceImplementation,
+        )
+        return refactorableFunctionsHandler(project, filePath, currentCode) {
+            ExtensionAPI.fnToRefactor(params, cacheParams, delta)
+        }
     }
 
     fun refactor(
@@ -122,9 +160,21 @@ class AceService :
     private suspend fun refactorableFunctionsHandler(
         editor: Editor,
         getFunctions: () -> List<com.codescene.data.ace.FnToRefactor>,
+    ): Boolean =
+        refactorableFunctionsHandler(
+            project = editor.project!!,
+            filePath = editor.virtualFile.path,
+            content = editor.document.text,
+            getFunctions = getFunctions,
+        )
+
+    private suspend fun refactorableFunctionsHandler(
+        project: Project,
+        filePath: String,
+        content: String,
+        getFunctions: () -> List<com.codescene.data.ace.FnToRefactor>,
     ): Boolean {
-        val project = editor.project!!
-        val path = editor.virtualFile.path
+        val path = normalizeAbsolutePath(filePath)
         val projectServiceProvider = CodeSceneProjectServiceProvider.getInstance(project)
         val orchestrator =
             RefactorableFunctionsOrchestrator(
@@ -135,13 +185,14 @@ class AceService :
         val result =
             orchestrator.fetchAndCache(
                 filePath = path,
-                content = editor.document.text,
+                content = content,
                 serviceName = "$serviceImplementation - ${project.name}",
                 getFunctions = { runWithClassLoaderChange { getFunctions() } },
             )
 
         val entry = AceRefactorableFunctionCacheEntry(result.filePath, result.content, result.functions)
         AceEntryOrchestrator.getInstance(project).updateCurrentAceView(entry)
+        updateMonitor(project)
         return result.functions.isNotEmpty()
     }
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
@@ -67,15 +67,15 @@ class AceService :
         cacheParams: CacheParams,
         review: Review,
         editor: Editor,
-    ): Boolean {
-        val codeSmells = review.fileLevelCodeSmells + review.functionLevelCodeSmells.flatMap { it.codeSmells }
-        Log.debug(
-            "Getting refactorable functions for ${editor.virtualFile.path} based on review with $codeSmells...",
-            serviceImplementation,
+    ): Boolean =
+        getRefactorableFunctions(
+            project = editor.project!!,
+            filePath = editor.virtualFile.path,
+            currentCode = editor.document.text,
+            params = params,
+            cacheParams = cacheParams,
+            review = review,
         )
-
-        return refactorableFunctionsHandler(editor) { ExtensionAPI.fnToRefactor(params, cacheParams, codeSmells) }
-    }
 
     suspend fun getRefactorableFunctions(
         project: Project,
@@ -100,13 +100,15 @@ class AceService :
         cacheParams: CacheParams,
         delta: Delta,
         editor: Editor,
-    ): Boolean {
-        Log.debug(
-            "Getting refactorable functions for ${editor.virtualFile.path} based on delta...",
-            serviceImplementation,
+    ): Boolean =
+        getRefactorableFunctions(
+            project = editor.project!!,
+            filePath = editor.virtualFile.path,
+            currentCode = editor.document.text,
+            params = params,
+            cacheParams = cacheParams,
+            delta = delta,
         )
-        return refactorableFunctionsHandler(editor) { ExtensionAPI.fnToRefactor(params, cacheParams, delta) }
-    }
 
     suspend fun getRefactorableFunctions(
         project: Project,
@@ -156,17 +158,6 @@ class AceService :
     fun cancelActiveRefactor() {
         refactorLaunchCoordinator.cancelActiveRefactor()
     }
-
-    private suspend fun refactorableFunctionsHandler(
-        editor: Editor,
-        getFunctions: () -> List<com.codescene.data.ace.FnToRefactor>,
-    ): Boolean =
-        refactorableFunctionsHandler(
-            project = editor.project!!,
-            filePath = editor.virtualFile.path,
-            content = editor.document.text,
-            getFunctions = getFunctions,
-        )
 
     private suspend fun refactorableFunctionsHandler(
         project: Project,

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
@@ -27,12 +27,46 @@ import com.codescene.jetbrains.platform.webview.util.updateMonitor
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.withContext
+
+internal sealed class RefactorableFunctionsSource {
+    abstract fun analysisLabel(): String
+
+    abstract fun fetch(
+        params: CodeParams,
+        cacheParams: CacheParams,
+    ): List<com.codescene.data.ace.FnToRefactor>
+
+    data class FromReview(
+        val review: Review,
+    ) : RefactorableFunctionsSource() {
+        private val codeSmells by lazy {
+            review.fileLevelCodeSmells + review.functionLevelCodeSmells.flatMap { it.codeSmells }
+        }
+
+        override fun analysisLabel(): String = "review with $codeSmells"
+
+        override fun fetch(
+            params: CodeParams,
+            cacheParams: CacheParams,
+        ): List<com.codescene.data.ace.FnToRefactor> = ExtensionAPI.fnToRefactor(params, cacheParams, codeSmells)
+    }
+
+    data class FromDelta(
+        val delta: Delta,
+    ) : RefactorableFunctionsSource() {
+        override fun analysisLabel(): String = "delta"
+
+        override fun fetch(
+            params: CodeParams,
+            cacheParams: CacheParams,
+        ): List<com.codescene.data.ace.FnToRefactor> = ExtensionAPI.fnToRefactor(params, cacheParams, delta)
+    }
+}
 
 @Service
 class AceService :
@@ -57,73 +91,25 @@ class AceService :
         preflightOrchestrator.runPreflight(force = force)
 
     /**
-     * Retrieves refactorable functions based on the full Review result.
+     * Retrieves refactorable functions from a [RefactorableFunctionsSource].
      *
-     * The Review result provides all refactorable functions in a file. This is a more comprehensive analysis
-     * compared to the *Delta review*.
+     * Use [RefactorableFunctionsSource.FromReview] for full review results (more comprehensive than delta).
+     * Use [RefactorableFunctionsSource.FromDelta] for delta-based analysis.
      */
-    suspend fun getRefactorableFunctions(
-        params: CodeParams,
-        cacheParams: CacheParams,
-        review: Review,
-        editor: Editor,
-    ): Boolean =
-        getRefactorableFunctions(
-            project = editor.project!!,
-            filePath = editor.virtualFile.path,
-            currentCode = editor.document.text,
-            params = params,
-            cacheParams = cacheParams,
-            review = review,
-        )
-
-    suspend fun getRefactorableFunctions(
+    internal suspend fun getRefactorableFunctions(
         project: Project,
         filePath: String,
         currentCode: String,
         params: CodeParams,
         cacheParams: CacheParams,
-        review: Review,
+        source: RefactorableFunctionsSource,
     ): Boolean {
-        val codeSmells = review.fileLevelCodeSmells + review.functionLevelCodeSmells.flatMap { it.codeSmells }
         Log.debug(
-            "Getting refactorable functions for $filePath based on review with $codeSmells...",
+            "Getting refactorable functions for $filePath based on ${source.analysisLabel()}...",
             serviceImplementation,
         )
         return refactorableFunctionsHandler(project, filePath, currentCode) {
-            ExtensionAPI.fnToRefactor(params, cacheParams, codeSmells)
-        }
-    }
-
-    suspend fun getRefactorableFunctions(
-        params: CodeParams,
-        cacheParams: CacheParams,
-        delta: Delta,
-        editor: Editor,
-    ): Boolean =
-        getRefactorableFunctions(
-            project = editor.project!!,
-            filePath = editor.virtualFile.path,
-            currentCode = editor.document.text,
-            params = params,
-            cacheParams = cacheParams,
-            delta = delta,
-        )
-
-    suspend fun getRefactorableFunctions(
-        project: Project,
-        filePath: String,
-        currentCode: String,
-        params: CodeParams,
-        cacheParams: CacheParams,
-        delta: Delta,
-    ): Boolean {
-        Log.debug(
-            "Getting refactorable functions for $filePath based on delta...",
-            serviceImplementation,
-        )
-        return refactorableFunctionsHandler(project, filePath, currentCode) {
-            ExtensionAPI.fnToRefactor(params, cacheParams, delta)
+            source.fetch(params, cacheParams)
         }
     }
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/CachedReviewService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/CachedReviewService.kt
@@ -17,9 +17,9 @@ import com.codescene.jetbrains.platform.editor.UIRefreshService
 import com.codescene.jetbrains.platform.editor.codeVision.CodeSceneCodeVisionProvider
 import com.codescene.jetbrains.platform.util.AceEntryOrchestrator
 import com.codescene.jetbrains.platform.util.Log
-import com.codescene.jetbrains.platform.util.refreshAceFromDelta
 import com.codescene.jetbrains.platform.util.isFileSupported
 import com.codescene.jetbrains.platform.util.isPathSupportedForReview
+import com.codescene.jetbrains.platform.util.refreshAceFromDelta
 import com.codescene.jetbrains.platform.webview.util.updateMonitor
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/CachedReviewService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/CachedReviewService.kt
@@ -1,7 +1,5 @@
 package com.codescene.jetbrains.platform.api
 
-import com.codescene.ExtensionAPI.CacheParams
-import com.codescene.ExtensionAPI.CodeParams
 import com.codescene.jetbrains.core.delta.DeltaCacheEntry
 import com.codescene.jetbrains.core.delta.DeltaCacheQuery
 import com.codescene.jetbrains.core.git.pathFileName
@@ -11,16 +9,15 @@ import com.codescene.jetbrains.core.review.CodeReviewer
 import com.codescene.jetbrains.core.review.ReviewCacheQuery
 import com.codescene.jetbrains.core.review.ReviewOrchestrator
 import com.codescene.jetbrains.core.review.resolveDeltaExecutionPlan
-import com.codescene.jetbrains.core.review.shouldCheckRefactorableFunctions
 import com.codescene.jetbrains.core.review.shouldRefreshAfterReviewFlow
 import com.codescene.jetbrains.core.util.normalizeAbsolutePath
-import com.codescene.jetbrains.core.util.resolveCliCacheFileName
 import com.codescene.jetbrains.platform.di.CodeSceneApplicationServiceProvider
 import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
 import com.codescene.jetbrains.platform.editor.UIRefreshService
 import com.codescene.jetbrains.platform.editor.codeVision.CodeSceneCodeVisionProvider
 import com.codescene.jetbrains.platform.util.AceEntryOrchestrator
 import com.codescene.jetbrains.platform.util.Log
+import com.codescene.jetbrains.platform.util.refreshAceFromDelta
 import com.codescene.jetbrains.platform.util.isFileSupported
 import com.codescene.jetbrains.platform.util.isPathSupportedForReview
 import com.codescene.jetbrains.platform.webview.util.updateMonitor
@@ -237,27 +234,8 @@ class CachedReviewService(
             "CodeSceneCachedReview",
         )
         val delta = deltaResult.delta
-        if (delta != null &&
-            !reviewMiss &&
-            shouldCheckRefactorableFunctions(
-                applicationServiceProvider.settingsProvider,
-                applicationServiceProvider.aceService,
-                editor.virtualFile.extension,
-            )
-        ) {
-            val filePath = editor.virtualFile.path
-            val cliFileName =
-                resolveCliCacheFileName(filePath, serviceProvider.gitService.getRepoRelativePath(filePath))
-            val aceParams = CodeParams(currentCode, cliFileName)
-            val cachePath = serviceProvider.cliCacheService.getCachePath()
-            Log.info(
-                "cachedReview ACE cachePath=$cachePath cliFileName=$cliFileName userDir=${System.getProperty(
-                    "user.dir",
-                )}",
-                "CachedReviewService",
-            )
-            val cacheParams = CacheParams(cachePath)
-            AceService.getInstance().getRefactorableFunctions(aceParams, cacheParams, delta, editor)
+        if (delta != null && !reviewMiss) {
+            refreshAceFromDelta(project, path, fileName, currentCode, delta)
         }
         return DeltaHandlingResult(didHandleDelta = true)
     }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/PathBasedReviewHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/PathBasedReviewHandler.kt
@@ -7,8 +7,11 @@ import com.codescene.jetbrains.core.review.BaselineReviewCacheQuery
 import com.codescene.jetbrains.core.review.ReviewCacheQuery
 import com.codescene.jetbrains.core.review.resolveDeltaExecutionPlan
 import com.codescene.jetbrains.core.review.resolveProgressMessage
+import com.codescene.jetbrains.core.util.normalizeAbsolutePath
 import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
 import com.codescene.jetbrains.platform.util.Log
+import com.codescene.jetbrains.platform.util.refreshAceFromDelta
+import com.codescene.jetbrains.platform.util.refreshAceFromReview
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -78,7 +81,7 @@ class PathBasedReviewHandler(private val project: Project) {
                 "reviewByPath review cache hit, delta miss path=$filePath",
                 "CodeSceneCachedReview",
             )
-            handleDeltaByPath(filePath, fileName, currentCode, cachedReview.score.orElse(null))
+            handleDeltaByPath(filePath, fileName, currentCode, cachedReview.score.orElse(null), reviewMiss = false)
             return
         }
 
@@ -97,11 +100,13 @@ class PathBasedReviewHandler(private val project: Project) {
             return
         }
 
+        refreshAceFromReview(project, filePath, fileName, currentCode, review)
+
         Log.info(
             "reviewByPath completed path=$filePath totalTime=${System.currentTimeMillis() - startTime}ms",
             "CodeSceneCachedReview",
         )
-        handleDeltaByPath(filePath, fileName, currentCode, review.score.orElse(null))
+        handleDeltaByPath(filePath, fileName, currentCode, review.score.orElse(null), reviewMiss = true)
     }
 
     private suspend fun handleDeltaByPath(
@@ -109,6 +114,7 @@ class PathBasedReviewHandler(private val project: Project) {
         fileName: String,
         currentCode: String,
         currentScore: Double?,
+        reviewMiss: Boolean,
     ) {
         val startTime = System.currentTimeMillis()
         val gitStart = System.currentTimeMillis()
@@ -169,6 +175,15 @@ class PathBasedReviewHandler(private val project: Project) {
             "handleDeltaByPath deltaAnalysis took ${System.currentTimeMillis() - deltaStart}ms file=$fileName",
             "CodeSceneCachedReview",
         )
+        if (!reviewMiss) {
+            val path = normalizeAbsolutePath(filePath)
+            val baselineCode = serviceProvider.gitService.getBranchCreationCommitCode(path)
+            val query = DeltaCacheQuery(path, baselineCode, currentCode)
+            val (_, delta) = serviceProvider.deltaCacheService.get(query)
+            if (delta != null) {
+                refreshAceFromDelta(project, filePath, fileName, currentCode, delta)
+            }
+        }
         Log.info(
             "handleDeltaByPath done file=$fileName totalTime=${System.currentTimeMillis() - startTime}ms",
             "CodeSceneCachedReview",

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/PathBasedReviewHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/PathBasedReviewHandler.kt
@@ -116,9 +116,10 @@ class PathBasedReviewHandler(private val project: Project) {
         currentScore: Double?,
         reviewMiss: Boolean,
     ) {
+        val normalizedPath = normalizeAbsolutePath(filePath)
         val startTime = System.currentTimeMillis()
         val gitStart = System.currentTimeMillis()
-        val baselineCode = serviceProvider.gitService.getBranchCreationCommitCode(filePath)
+        val baselineCode = serviceProvider.gitService.getBranchCreationCommitCode(normalizedPath)
         val gitElapsed = System.currentTimeMillis() - gitStart
         Log.info(
             "handleDeltaByPath gitBaseline took ${gitElapsed}ms file=$fileName baselineLen=${baselineCode.length}",
@@ -137,7 +138,7 @@ class PathBasedReviewHandler(private val project: Project) {
         if (plan.shouldCacheEmptyDelta) {
             serviceProvider.deltaCacheService.put(
                 DeltaCacheEntry(
-                    filePath = filePath,
+                    filePath = normalizedPath,
                     headContent = baselineCode,
                     currentFileContent = currentCode,
                     deltaApiResponse = null,
@@ -151,7 +152,7 @@ class PathBasedReviewHandler(private val project: Project) {
         }
 
         val deltaCacheStart = System.currentTimeMillis()
-        val query = DeltaCacheQuery(filePath, baselineCode, currentCode)
+        val query = DeltaCacheQuery(normalizedPath, baselineCode, currentCode)
         val (deltaHit, _) = serviceProvider.deltaCacheService.get(query)
         Log.info(
             "handleDeltaByPath deltaCacheCheck took ${System.currentTimeMillis() - deltaCacheStart}ms file=$fileName",
@@ -169,16 +170,14 @@ class PathBasedReviewHandler(private val project: Project) {
         val deltaStart = System.currentTimeMillis()
         val deltaProgressMessage = resolveProgressMessage(fileName, false)
         serviceProvider.progressService.runWithProgress(deltaProgressMessage) {
-            deltaService.performDeltaAnalysisByPath(filePath, fileName, currentCode)
+            deltaService.performDeltaAnalysisByPath(normalizedPath, fileName, currentCode)
         }
         Log.info(
             "handleDeltaByPath deltaAnalysis took ${System.currentTimeMillis() - deltaStart}ms file=$fileName",
             "CodeSceneCachedReview",
         )
         if (!reviewMiss) {
-            val path = normalizeAbsolutePath(filePath)
-            val baselineCode = serviceProvider.gitService.getBranchCreationCommitCode(path)
-            val query = DeltaCacheQuery(path, baselineCode, currentCode)
+            val query = DeltaCacheQuery(normalizedPath, baselineCode, currentCode)
             val (_, delta) = serviceProvider.deltaCacheService.get(query)
             if (delta != null) {
                 refreshAceFromDelta(project, filePath, fileName, currentCode, delta)

--- a/src/main/kotlin/com/codescene/jetbrains/platform/delta/PlatformDeltaCacheService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/delta/PlatformDeltaCacheService.kt
@@ -31,7 +31,6 @@ class PlatformDeltaCacheService(
         val (hit, _) = result
         if (hit) {
             setIncludeInCodeHealthMonitor(query.filePath, true)
-            updateMonitor(project)
         }
         return result
     }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
@@ -12,7 +12,7 @@ import com.codescene.jetbrains.core.models.settings.AceStatus
 import com.codescene.jetbrains.core.models.shared.FileMetaType
 import com.codescene.jetbrains.core.review.AceEntryCommand
 import com.codescene.jetbrains.core.review.AceRefactorableFunctionCacheEntry
-import com.codescene.jetbrains.core.review.AceRefactorableFunctionCacheQuery
+import com.codescene.jetbrains.core.util.resolveAceCandidatesForMonitor
 import com.codescene.jetbrains.core.review.resolveAceEntryPointCommand
 import com.codescene.jetbrains.core.review.resolveAceErrorViewParams
 import com.codescene.jetbrains.core.review.resolveAceStatusChange
@@ -121,11 +121,13 @@ class AceEntryOrchestrator(private val project: Project) {
         content: String,
     ): List<FnToRefactor> {
         val cacheService = PlatformAceRefactorableFunctionsCacheService.getInstance(project)
-        val fresh = cacheService.get(AceRefactorableFunctionCacheQuery(path, content))
-        if (fresh.isNotEmpty()) return fresh
-        val stale = cacheService.getLastKnown(path)
-        Log.debug("ACE refactorable functions cache ${if (stale.isEmpty()) "miss" else "stale"} for $path.")
-        return stale
+        val candidates = resolveAceCandidatesForMonitor(cacheService, path, content)
+        if (candidates.isNotEmpty() &&
+            cacheService.get(path, content).isEmpty()
+        ) {
+            Log.debug("ACE refactorable functions cache stale for $path.")
+        }
+        return candidates
     }
 
     suspend fun checkContainsRefactorableFunctions(

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
@@ -20,6 +20,7 @@ import com.codescene.jetbrains.core.util.resolveAceCandidatesForMonitor
 import com.codescene.jetbrains.core.util.resolveCliCacheFileName
 import com.codescene.jetbrains.platform.UiLabelsBundle
 import com.codescene.jetbrains.platform.api.AceService
+import com.codescene.jetbrains.platform.api.RefactorableFunctionsSource
 import com.codescene.jetbrains.platform.di.CodeSceneApplicationServiceProvider
 import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
 import com.codescene.jetbrains.platform.review.PlatformAceRefactorableFunctionsCacheService
@@ -154,7 +155,14 @@ class AceEntryOrchestrator(private val project: Project) {
             "AceEntryOrchestrator",
         )
         val cacheParams = CacheParams(cachePath)
-        return AceService.getInstance().getRefactorableFunctions(aceParams, cacheParams, result, editor)
+        return AceService.getInstance().getRefactorableFunctions(
+            project = editor.project!!,
+            filePath = filePath,
+            currentCode = editor.document.text,
+            params = aceParams,
+            cacheParams = cacheParams,
+            source = RefactorableFunctionsSource.FromReview(result),
+        )
     }
 
     fun handleRefactoringResult(

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
@@ -12,11 +12,11 @@ import com.codescene.jetbrains.core.models.settings.AceStatus
 import com.codescene.jetbrains.core.models.shared.FileMetaType
 import com.codescene.jetbrains.core.review.AceEntryCommand
 import com.codescene.jetbrains.core.review.AceRefactorableFunctionCacheEntry
-import com.codescene.jetbrains.core.util.resolveAceCandidatesForMonitor
 import com.codescene.jetbrains.core.review.resolveAceEntryPointCommand
 import com.codescene.jetbrains.core.review.resolveAceErrorViewParams
 import com.codescene.jetbrains.core.review.resolveAceStatusChange
 import com.codescene.jetbrains.core.util.AceEntryPoint
+import com.codescene.jetbrains.core.util.resolveAceCandidatesForMonitor
 import com.codescene.jetbrains.core.util.resolveCliCacheFileName
 import com.codescene.jetbrains.platform.UiLabelsBundle
 import com.codescene.jetbrains.platform.api.AceService

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceFileRefresh.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceFileRefresh.kt
@@ -31,7 +31,14 @@ suspend fun refreshAceFromReview(
         resolveCliCacheFileName(normalizedPath, services.gitService.getRepoRelativePath(normalizedPath))
     val params = CodeParams(currentCode, cliFileName)
     val cacheParams = CacheParams(services.cliCacheService.getCachePath())
-    return AceService.getInstance().getRefactorableFunctions(project, normalizedPath, currentCode, params, cacheParams, review)
+    return AceService.getInstance().getRefactorableFunctions(
+        project,
+        normalizedPath,
+        currentCode,
+        params,
+        cacheParams,
+        review,
+    )
 }
 
 suspend fun refreshAceFromDelta(
@@ -52,5 +59,12 @@ suspend fun refreshAceFromDelta(
         resolveCliCacheFileName(normalizedPath, services.gitService.getRepoRelativePath(normalizedPath))
     val params = CodeParams(currentCode, cliFileName)
     val cacheParams = CacheParams(services.cliCacheService.getCachePath())
-    return AceService.getInstance().getRefactorableFunctions(project, normalizedPath, currentCode, params, cacheParams, delta)
+    return AceService.getInstance().getRefactorableFunctions(
+        project,
+        normalizedPath,
+        currentCode,
+        params,
+        cacheParams,
+        delta,
+    )
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceFileRefresh.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceFileRefresh.kt
@@ -1,0 +1,56 @@
+package com.codescene.jetbrains.platform.util
+
+import com.codescene.ExtensionAPI.CacheParams
+import com.codescene.ExtensionAPI.CodeParams
+import com.codescene.data.delta.Delta
+import com.codescene.data.review.Review
+import com.codescene.jetbrains.core.review.shouldCheckRefactorableFunctions
+import com.codescene.jetbrains.core.util.extractExtension
+import com.codescene.jetbrains.core.util.normalizeAbsolutePath
+import com.codescene.jetbrains.core.util.resolveCliCacheFileName
+import com.codescene.jetbrains.platform.api.AceService
+import com.codescene.jetbrains.platform.di.CodeSceneApplicationServiceProvider
+import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
+import com.intellij.openapi.project.Project
+
+suspend fun refreshAceFromReview(
+    project: Project,
+    filePath: String,
+    fileName: String,
+    currentCode: String,
+    review: Review,
+): Boolean {
+    val fileExtension = extractExtension(fileName)
+    val appServices = CodeSceneApplicationServiceProvider.getInstance()
+    if (!shouldCheckRefactorableFunctions(appServices.settingsProvider, appServices.aceService, fileExtension)) {
+        return false
+    }
+    val services = CodeSceneProjectServiceProvider.getInstance(project)
+    val normalizedPath = normalizeAbsolutePath(filePath)
+    val cliFileName =
+        resolveCliCacheFileName(normalizedPath, services.gitService.getRepoRelativePath(normalizedPath))
+    val params = CodeParams(currentCode, cliFileName)
+    val cacheParams = CacheParams(services.cliCacheService.getCachePath())
+    return AceService.getInstance().getRefactorableFunctions(project, normalizedPath, currentCode, params, cacheParams, review)
+}
+
+suspend fun refreshAceFromDelta(
+    project: Project,
+    filePath: String,
+    fileName: String,
+    currentCode: String,
+    delta: Delta,
+): Boolean {
+    val fileExtension = extractExtension(fileName)
+    val appServices = CodeSceneApplicationServiceProvider.getInstance()
+    if (!shouldCheckRefactorableFunctions(appServices.settingsProvider, appServices.aceService, fileExtension)) {
+        return false
+    }
+    val services = CodeSceneProjectServiceProvider.getInstance(project)
+    val normalizedPath = normalizeAbsolutePath(filePath)
+    val cliFileName =
+        resolveCliCacheFileName(normalizedPath, services.gitService.getRepoRelativePath(normalizedPath))
+    val params = CodeParams(currentCode, cliFileName)
+    val cacheParams = CacheParams(services.cliCacheService.getCachePath())
+    return AceService.getInstance().getRefactorableFunctions(project, normalizedPath, currentCode, params, cacheParams, delta)
+}

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceFileRefresh.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceFileRefresh.kt
@@ -9,6 +9,7 @@ import com.codescene.jetbrains.core.util.extractExtension
 import com.codescene.jetbrains.core.util.normalizeAbsolutePath
 import com.codescene.jetbrains.core.util.resolveCliCacheFileName
 import com.codescene.jetbrains.platform.api.AceService
+import com.codescene.jetbrains.platform.api.RefactorableFunctionsSource
 import com.codescene.jetbrains.platform.di.CodeSceneApplicationServiceProvider
 import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
 import com.intellij.openapi.project.Project
@@ -37,7 +38,7 @@ suspend fun refreshAceFromReview(
         currentCode,
         params,
         cacheParams,
-        review,
+        RefactorableFunctionsSource.FromReview(review),
     )
 }
 
@@ -65,6 +66,6 @@ suspend fun refreshAceFromDelta(
         currentCode,
         params,
         cacheParams,
-        delta,
+        RefactorableFunctionsSource.FromDelta(delta),
     )
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/UpdateMonitor.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/UpdateMonitor.kt
@@ -4,7 +4,7 @@ import com.codescene.jetbrains.core.flag.RuntimeFlags
 import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.core.mapper.CodeHealthMonitorMapper
 import com.codescene.jetbrains.core.models.View
-import com.codescene.jetbrains.core.review.AceRefactorableFunctionCacheQuery
+import com.codescene.jetbrains.core.util.resolveAceCandidatesForMonitor
 import com.codescene.jetbrains.core.util.resolveFunctionToRefactor
 import com.codescene.jetbrains.core.util.toAutoRefactorConfig
 import com.codescene.jetbrains.platform.api.CachedReviewService
@@ -61,7 +61,7 @@ private fun updateMonitorImpl(project: Project) {
             activeJobs = activeJobs,
             functionToRefactorResolver = { filePath, contentSha, fn ->
                 val cache = PlatformAceRefactorableFunctionsCacheService.getInstance(project)
-                val candidates = cache.get(AceRefactorableFunctionCacheQuery(filePath, contentSha))
+                val candidates = resolveAceCandidatesForMonitor(cache, filePath, contentSha)
                 resolveFunctionToRefactor(candidates, fn)
             },
             autoRefactorConfig = toAutoRefactorConfig(services.settingsProvider.currentState()),


### PR DESCRIPTION
## Summary

- Align Code Health Monitor ACE lookup with Code Vision by using a shared resolver with stale cache fallback and canonical path keys.
- Refresh the monitor after ACE cache writes and populate ACE on path-based reviews (git change observer / periodic poller).
- Stop calling updateMonitor from delta cache get on hit to avoid premature monitor updates before ACE data exists.

## Test plan

- [ ] Open a changed file with CodeScene ACE Code Vision visible; confirm matching function row in Code Health Monitor has refactorable-fn.
- [ ] Edit function body while ACE lens still shows; confirm monitor still shows refactorable-fn (stale parity with Code Vision).
- [ ] Change a file outside the IDE (git CLI); confirm monitor updates after periodic/path-based review.
- [ ] On Windows, verify ACE data appears when file is reviewed via editor vs path-based flow.

Made with [Cursor](https://cursor.com)