### PR TITLE
fix: avoid synchronous git under ReadAction during file support check

### DIFF
--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
@@ -6,7 +6,6 @@ import com.codescene.jetbrains.core.git.resolveClosestMainLineMergeBase
 import com.codescene.jetbrains.core.util.parseBranchCreationCommitFromReflog
 import com.codescene.jetbrains.platform.util.Log
 import com.intellij.dvcs.repo.Repository
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -157,9 +156,6 @@ class Git4IdeaGitService(val project: Project) : IGitService {
 
     internal fun resolveRepository(file: VirtualFile): GitRepository? {
         val manager = GitRepositoryManager.getInstance(project)
-        if (!ApplicationManager.getApplication().isDispatchThread) {
-            return manager.getRepositoryForFile(file)
-        }
         val vcsRoot = ProjectLevelVcsManager.getInstance(project).getVcsRootFor(file) ?: return null
         return manager.getRepositoryForRootQuick(vcsRoot)
             ?: findDeepestMatchingRepository(manager.repositories, file.path)

--- a/src/main/kotlin/com/codescene/jetbrains/platform/listeners/FileEditorLifecycleListener.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/listeners/FileEditorLifecycleListener.kt
@@ -83,8 +83,7 @@ class FileEditorLifecycleListener : FileEditorManagerListener {
         if (reviewService.activeReviewCalls.contains(file.path)) return
         reviewService.scope.launch {
             if (project.isDisposed) return@launch
-            val supported = ReadAction.compute<Boolean, RuntimeException> { isFileSupported(project, file) }
-            if (!supported) return@launch
+            if (!isFileSupported(project, file)) return@launch
             val text = ReadAction.compute<String, RuntimeException> { editor.document.text }
             val services = CodeSceneProjectServiceProvider.getInstance(project)
             if (services.reviewCacheService.get(ReviewCacheQuery(text, file.path)) != null) return@launch

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitServiceTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitServiceTest.kt
@@ -53,15 +53,21 @@ class Git4IdeaGitServiceTest {
     }
 
     @Test
-    fun `resolveRepository uses getRepositoryForFile off EDT`() {
+    fun `resolveRepository uses getRepositoryForRootQuick off EDT`() {
+        val vcsRoot = mockk<VirtualFile>(relaxed = true)
+
         every { mockApplication.isDispatchThread } returns false
-        every { mockRepoManager.getRepositoryForFile(file) } returns mockRepository
+        mockkStatic(ProjectLevelVcsManager::class)
+        val mockVcsManager = mockk<ProjectLevelVcsManager>(relaxed = true)
+        every { ProjectLevelVcsManager.getInstance(project) } returns mockVcsManager
+        every { mockVcsManager.getVcsRootFor(file) } returns vcsRoot
+        every { mockRepoManager.getRepositoryForRootQuick(vcsRoot) } returns mockRepository
 
         val result = gitService.resolveRepository(file)
 
         assertSame(mockRepository, result)
-        verify(exactly = 1) { mockRepoManager.getRepositoryForFile(file) }
-        verify(exactly = 0) { mockRepoManager.getRepositoryForRootQuick(any<VirtualFile>()) }
+        verify(exactly = 0) { mockRepoManager.getRepositoryForFile(any<VirtualFile>()) }
+        verify(exactly = 1) { mockRepoManager.getRepositoryForRootQuick(vcsRoot) }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Unify `Git4IdeaGitService.resolveRepository` to always use `getRepositoryForRootQuick` and deepest nested-repo fallback, never `getRepositoryForFile`, so git subprocesses are not started under a read lock.
- Narrow `FileEditorLifecycleListener.ensureInitialReview` so `isFileSupported` (including gitignore checks) runs outside `ReadAction`; keep read lock only for `editor.document.text`.
- Completes the EDT-safe repository lookup from #150 for background/ReadAction callers that hit `isIgnored` during initial review scheduling.

## Test plan
- [x] `make iter NULL=NUL` (format, ktlint, delta, buildPlugin, test)
- [x] `Git4IdeaGitServiceTest` updated for off-EDT quick lookup
- [ ] Manual: switch editor tabs in a git project; confirm no `OSProcessHandler.checkEdtAndReadAction` in IDE log
- [ ] Manual: open gitignored file; verify it is excluded from review once repos are loaded