### PR TITLE
Implement StaleItemCleanup

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/cleanup/StaleItemCleanup.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/cleanup/StaleItemCleanup.kt
@@ -1,0 +1,31 @@
+package com.codescene.jetbrains.core.cleanup
+
+import com.codescene.jetbrains.core.contracts.IDeltaCacheService
+import com.codescene.jetbrains.core.contracts.ILogger
+import com.codescene.jetbrains.core.git.pathCacheKey
+
+class StaleItemCleanup(
+    private val deltaCacheService: IDeltaCacheService,
+    private val logger: ILogger,
+) {
+    fun cleanupStaleItems(
+        gitChangedFiles: Set<String>,
+        visibleEditorFiles: Set<String>,
+    ): List<String> {
+        val allowedFiles = gitChangedFiles + visibleEditorFiles
+        val allowedKeys = allowedFiles.map { pathCacheKey(it) }.toSet()
+
+        val cachedItems = deltaCacheService.getAll()
+        val removedPaths = mutableListOf<String>()
+
+        for ((filePath, _) in cachedItems) {
+            val fileKey = pathCacheKey(filePath)
+            if (!allowedKeys.contains(fileKey)) {
+                logger.info("Removing stale item: $filePath", "StaleItemCleanup")
+                deltaCacheService.setIncludeInCodeHealthMonitor(filePath, false)
+                removedPaths.add(filePath)
+            }
+        }
+        return removedPaths
+    }
+}

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/delta/DeltaCacheService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/delta/DeltaCacheService.kt
@@ -110,7 +110,7 @@ open class DeltaCacheService(
         )
     }
 
-    fun setIncludeInCodeHealthMonitor(
+    open fun setIncludeInCodeHealthMonitor(
         filePath: String,
         include: Boolean,
     ) {

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/cleanup/StaleItemCleanupTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/cleanup/StaleItemCleanupTest.kt
@@ -1,0 +1,173 @@
+package com.codescene.jetbrains.core.cleanup
+
+import com.codescene.data.delta.Delta
+import com.codescene.jetbrains.core.TestLogger
+import com.codescene.jetbrains.core.testdoubles.InMemoryDeltaCacheService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class StaleItemCleanupTest {
+    private lateinit var deltaCacheService: InMemoryDeltaCacheService
+    private lateinit var staleItemCleanup: StaleItemCleanup
+
+    @Before
+    fun setUp() {
+        deltaCacheService = InMemoryDeltaCacheService()
+        staleItemCleanup = StaleItemCleanup(deltaCacheService, TestLogger)
+    }
+
+    private fun createDelta(scoreChange: Double = 1.0): Delta {
+        val delta = mockk<Delta>()
+        every { delta.scoreChange } returns scoreChange
+        return delta
+    }
+
+    private fun addToCache(filePath: String) {
+        deltaCacheService.put(
+            com.codescene.jetbrains.core.delta.DeltaCacheEntry(
+                filePath = filePath,
+                headContent = "original",
+                currentFileContent = "modified",
+                deltaApiResponse = createDelta(),
+            ),
+        )
+    }
+
+    @Test
+    fun `stale item is removed when not in git changes AND not in visible editors`() {
+        addToCache("/project/src/stale.kt")
+
+        val removed =
+            staleItemCleanup.cleanupStaleItems(
+                gitChangedFiles = emptySet(),
+                visibleEditorFiles = emptySet(),
+            )
+
+        assertEquals(1, removed.size)
+        assertEquals("/project/src/stale.kt", removed[0])
+        assertEquals(0, deltaCacheService.getAll().size)
+    }
+
+    @Test
+    fun `item is NOT removed when present in git changes`() {
+        val filePath = "/project/src/changed.kt"
+        addToCache(filePath)
+
+        val removed =
+            staleItemCleanup.cleanupStaleItems(
+                gitChangedFiles = setOf(filePath),
+                visibleEditorFiles = emptySet(),
+            )
+
+        assertEquals(0, removed.size)
+        assertEquals(1, deltaCacheService.getAll().size)
+    }
+
+    @Test
+    fun `item is NOT removed when present in visible editors`() {
+        val filePath = "/project/src/open.kt"
+        addToCache(filePath)
+
+        val removed =
+            staleItemCleanup.cleanupStaleItems(
+                gitChangedFiles = emptySet(),
+                visibleEditorFiles = setOf(filePath),
+            )
+
+        assertEquals(0, removed.size)
+        assertEquals(1, deltaCacheService.getAll().size)
+    }
+
+    @Test
+    fun `item is NOT removed when present in both git changes and visible editors`() {
+        val filePath = "/project/src/both.kt"
+        addToCache(filePath)
+
+        val removed =
+            staleItemCleanup.cleanupStaleItems(
+                gitChangedFiles = setOf(filePath),
+                visibleEditorFiles = setOf(filePath),
+            )
+
+        assertEquals(0, removed.size)
+        assertEquals(1, deltaCacheService.getAll().size)
+    }
+
+    @Test
+    fun `path comparison handles Windows backslashes vs Unix forward slashes`() {
+        addToCache("C:\\project\\src\\file.kt")
+
+        val removed =
+            staleItemCleanup.cleanupStaleItems(
+                gitChangedFiles = setOf("C:/project/src/file.kt"),
+                visibleEditorFiles = emptySet(),
+            )
+
+        assertEquals(0, removed.size)
+        assertEquals(1, deltaCacheService.getAll().size)
+    }
+
+    @Test
+    fun `multiple items - only stale ones are removed`() {
+        addToCache("/project/src/kept1.kt")
+        addToCache("/project/src/kept2.kt")
+        addToCache("/project/src/stale1.kt")
+        addToCache("/project/src/stale2.kt")
+
+        val removed =
+            staleItemCleanup.cleanupStaleItems(
+                gitChangedFiles = setOf("/project/src/kept1.kt"),
+                visibleEditorFiles = setOf("/project/src/kept2.kt"),
+            )
+
+        assertEquals(2, removed.size)
+        assertTrue(removed.contains("/project/src/stale1.kt"))
+        assertTrue(removed.contains("/project/src/stale2.kt"))
+        assertEquals(2, deltaCacheService.getAll().size)
+    }
+
+    @Test
+    fun `empty cache produces no errors`() {
+        val removed =
+            staleItemCleanup.cleanupStaleItems(
+                gitChangedFiles = setOf("/project/src/file.kt"),
+                visibleEditorFiles = setOf("/project/src/other.kt"),
+            )
+
+        assertEquals(0, removed.size)
+    }
+
+    @Test
+    fun `cleanup returns list of removed file paths`() {
+        addToCache("/project/src/first.kt")
+        addToCache("/project/src/second.kt")
+
+        val removed =
+            staleItemCleanup.cleanupStaleItems(
+                gitChangedFiles = emptySet(),
+                visibleEditorFiles = emptySet(),
+            )
+
+        assertEquals(2, removed.size)
+        assertTrue(removed.contains("/project/src/first.kt"))
+        assertTrue(removed.contains("/project/src/second.kt"))
+    }
+
+    @Test
+    fun `item kept by visible editor with different path separator than cache`() {
+        addToCache("C:\\project\\src\\editor.kt")
+
+        val removed =
+            staleItemCleanup.cleanupStaleItems(
+                gitChangedFiles = emptySet(),
+                visibleEditorFiles = setOf("C:/project/src/editor.kt"),
+            )
+
+        assertEquals(0, removed.size)
+        assertEquals(1, deltaCacheService.getAll().size)
+    }
+}

--- a/src/main/kotlin/com/codescene/jetbrains/platform/delta/PlatformDeltaCacheService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/delta/PlatformDeltaCacheService.kt
@@ -77,4 +77,15 @@ class PlatformDeltaCacheService(
             )
         }
     }
+
+    override fun setIncludeInCodeHealthMonitor(
+        filePath: String,
+        include: Boolean,
+    ) {
+        val cacheKey = pathCacheKey(filePath)
+        val existing = cache[cacheKey] ?: return
+        if (existing.includeInCodeHealthMonitor == include) return
+        super.setIncludeInCodeHealthMonitor(filePath, include)
+        updateMonitor(project)
+    }
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/PeriodicChangeListerService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/PeriodicChangeListerService.kt
@@ -1,7 +1,9 @@
 package com.codescene.jetbrains.platform.git
 
+import com.codescene.jetbrains.core.cleanup.StaleItemCleanup
 import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.platform.api.CachedReviewService
+import com.codescene.jetbrains.platform.delta.PlatformDeltaCacheService
 import com.codescene.jetbrains.platform.util.Log
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
@@ -45,6 +47,8 @@ class PeriodicChangeListerService(
     private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
     private var workspacePath: String? = null
     private var gitRootPath: String? = null
+    private val openFilesObserver = OpenFilesObserverAdapter(project)
+    private val staleItemCleanup = StaleItemCleanup(PlatformDeltaCacheService.getInstance(project), Log)
 
     fun start() {
         val wsPath = project.basePath
@@ -76,6 +80,12 @@ class PeriodicChangeListerService(
 
         val changeLister = Git4IdeaChangeLister.getInstance(project)
         val changedFiles = runBlocking { changeLister.getAllChangedFiles(gitRoot, wsPath, emptySet()) }
+        val visibleFiles = openFilesObserver.getAllVisibleFileNames()
+
+        val removed = staleItemCleanup.cleanupStaleItems(changedFiles, visibleFiles)
+        if (removed.isNotEmpty()) {
+            Log.info("Cleaned up ${removed.size} stale items", "PeriodicChangeListerService")
+        }
 
         Log.info("Poll found ${changedFiles.size} changed files", "PeriodicChangeListerService")
 


### PR DESCRIPTION
Implement StaleItemCleanup and integate it into the PeriodicChangeListerService.

The idea is simple: if an item isn't either in the "git" set of files or the "open editors" set of files, then it's stale and therefore some sort of remnant.

We use `pathCacheKey` for a reliable comparison.

Finally, `setIncludeInCodeHealthMonitor` wasn't updating the monitor on item removals (as it wasn't needed before). So we make it call `updateMonitor` now.