### PR TITLE
fix: restore ACE isStale when source file paths differ in format

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/review/AceEntryLogic.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/review/AceEntryLogic.kt
@@ -6,6 +6,7 @@ import com.codescene.jetbrains.core.contracts.IAceService
 import com.codescene.jetbrains.core.contracts.IFileSystem
 import com.codescene.jetbrains.core.contracts.ILogger
 import com.codescene.jetbrains.core.contracts.ISettingsProvider
+import com.codescene.jetbrains.core.git.pathComparisonKey
 import com.codescene.jetbrains.core.models.AceCwfParams
 import com.codescene.jetbrains.core.models.CurrentAceViewData
 import com.codescene.jetbrains.core.models.RefactoringRequest
@@ -152,7 +153,7 @@ fun resolveAceViewUpdateParams(
     currentAceData: CurrentAceViewData,
     entry: AceRefactorableFunctionCacheEntry,
 ): AceCwfParams? {
-    if (currentAceData.filePath != entry.filePath) return null
+    if (pathComparisonKey(currentAceData.filePath) != pathComparisonKey(entry.filePath)) return null
 
     val state = resolveAceViewState(currentAceData.functionToRefactor, entry.result)
     if (!state.isStale && !state.isRangeDifferent) return null

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/AceEntryLogicTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/AceEntryLogicTest.kt
@@ -173,6 +173,25 @@ class AceEntryLogicTest {
     }
 
     @Test
+    fun `resolveAceViewUpdateParams matches paths that differ only by separator or drive letter casing`() {
+        val currentFn = mockFn("f", "old", 1, 2)
+        val updatedFn = mockFn("f", "new", 1, 2)
+        val current = CurrentAceViewData("C:/proj/Foo.kt", currentFn, refactorResponse = null)
+        val entry =
+            AceRefactorableFunctionCacheEntry(
+                filePath = "C:\\proj\\foo.kt",
+                content = "c",
+                result = listOf(updatedFn),
+            )
+
+        val result = resolveAceViewUpdateParams(current, entry)
+
+        assertNotNull(result)
+        assertEquals(true, result?.stale)
+        assertSame(updatedFn, result?.function)
+    }
+
+    @Test
     fun `resolveAceViewUpdateParams returns null when no stale and no range change`() {
         val currentFn = mockFn("f", "same", 1, 2)
         val updatedFn = mockFn("f", "same", 1, 2)

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceCwfHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceCwfHandler.kt
@@ -1,6 +1,7 @@
 package com.codescene.jetbrains.platform.util
 
 import com.codescene.data.ace.FnToRefactor
+import com.codescene.jetbrains.core.git.pathComparisonKey
 import com.codescene.jetbrains.core.models.CurrentAceViewData
 import com.codescene.jetbrains.core.models.shared.FileMetaType
 import com.codescene.jetbrains.core.review.AceRefactorableFunctionCacheEntry
@@ -85,7 +86,7 @@ class AceCwfHandler(private val project: Project) {
     fun updateCurrentAceView(entry: AceRefactorableFunctionCacheEntry) {
         val platformData = getAceUserData(project)
         val filePath = platformData?.aceData?.fileData?.fileName ?: return
-        if (filePath != entry.filePath) return
+        if (pathComparisonKey(filePath) != pathComparisonKey(entry.filePath)) return
 
         val currentAceData =
             CurrentAceViewData(


### PR DESCRIPTION
## Summary
- Compare ACE view file paths with \pathComparisonKey\ in \esolveAceViewUpdateParams\ and \AceCwfHandler.updateCurrentAceView\ so stale updates are not skipped when the ACE tab and refactorable-functions cache use different path string formats.
- Regression introduced when cache paths were normalized in #149 while stale gating still used raw string equality (common on Windows: \C:/proj/Foo.kt\ vs \C:\\proj\\foo.kt\).
- Add unit test covering separator and drive-letter casing differences.

## Test plan
- [x] \AceEntryLogicTest\ (including new path-alias case)
- [x] ktlintCheck (core + platform)
- [x] CodeScene pre-commit safeguard
- [ ] Manual: present ACE refactor, edit refactored function, confirm ACE webview receives \isStale: true\ after review/ACE cache refresh

Made with [Cursor](https://cursor.com)