### PR TITLE
Make CodeScene tool window observable for UI tests

### DIFF
--- a/src/main/kotlin/com/codescene/jetbrains/platform/toolwindow/HomeToolWindowFactory.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/toolwindow/HomeToolWindowFactory.kt
@@ -2,11 +2,13 @@ package com.codescene.jetbrains.platform.toolwindow
 
 import com.codescene.jetbrains.core.models.View
 import com.codescene.jetbrains.platform.webview.WebViewFactory
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 
-internal class HomeToolWindowFactory : ToolWindowFactory {
+// The tool window shell is safe to create during indexing; index-dependent work should guard itself explicitly.
+internal class HomeToolWindowFactory : ToolWindowFactory, DumbAware {
     /**
      * Creates and sets up the content for the *Home* ToolWindow in the JetBrains IDE.
      *

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/handler/CwfMessageHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/handler/CwfMessageHandler.kt
@@ -26,6 +26,7 @@ import com.codescene.jetbrains.platform.webview.WebViewInitializer
 import com.codescene.jetbrains.platform.webview.util.JsEmbedEscapes
 import com.codescene.jetbrains.platform.webview.util.aceAcknowledgeRefreshMessage
 import com.codescene.jetbrains.platform.webview.util.docsRefreshMessage
+import com.codescene.jetbrains.platform.webview.util.markCwfInitializedForUiTests
 import com.codescene.jetbrains.platform.webview.util.openDocs
 import com.codescene.jetbrains.platform.webview.util.resolveFnToRefactorForDocumentation
 import com.codescene.jetbrains.platform.webview.util.updateMonitor
@@ -165,6 +166,7 @@ class CwfMessageHandler(
                 lifecycle.setInitialized(View.HOME, true)
                 lifecycle.takePendingHome()
                 updateMonitor(project)
+                markCwfInitializedForUiTests(project, View.HOME)
             }
             View.ACE.value -> {
                 lifecycle.setInitialized(View.ACE, true)
@@ -173,6 +175,7 @@ class CwfMessageHandler(
                     postMessageDirect(View.ACE, queued, browser)
                 }
                 orchestrator.handleAceViewInitialized()
+                markCwfInitializedForUiTests(project, View.ACE)
             }
             View.DOCS.value -> {
                 lifecycle.setInitialized(View.DOCS, true)
@@ -186,6 +189,7 @@ class CwfMessageHandler(
                 if (message != null) {
                     postMessageDirect(View.DOCS, message, browser)
                 }
+                markCwfInitializedForUiTests(project, View.DOCS)
             }
             View.ACE_ACKNOWLEDGE.value -> {
                 lifecycle.setInitialized(View.ACE_ACKNOWLEDGE, true)
@@ -195,6 +199,7 @@ class CwfMessageHandler(
                 if (message != null) {
                     postMessageDirect(View.ACE_ACKNOWLEDGE, message, browser)
                 }
+                markCwfInitializedForUiTests(project, View.ACE_ACKNOWLEDGE)
             }
             else -> Unit
         }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/CwfUiTestDiagnostics.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/CwfUiTestDiagnostics.kt
@@ -1,0 +1,28 @@
+package com.codescene.jetbrains.platform.webview.util
+
+import com.codescene.jetbrains.core.models.View
+import com.codescene.jetbrains.platform.webview.WebViewInitializer
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+
+private fun isUiTestDiagnosticsEnabled(): Boolean =
+    System.getProperty("codescene.uiTestDiagnostics").equals("true", ignoreCase = true)
+
+/**
+ * Marks the JCEF Swing component for [view] with a stable name/accessibleName so that
+ * Remote Robot UI tests can confirm the CWF webapp called handleInit (i.e. the React
+ * webapp actually bootstrapped, not just that the JCEF shell exists).
+ *
+ * Only active when -Dcodescene.uiTestDiagnostics=true. No-op in normal runtime.
+ */
+fun markCwfInitializedForUiTests(
+    project: Project,
+    view: View,
+) {
+    if (!isUiTestDiagnosticsEnabled()) return
+    val component = WebViewInitializer.getInstance(project).getBrowser(view)?.component ?: return
+    ApplicationManager.getApplication().invokeLater {
+        component.name = "codescene-cwf-initialized-${view.value}"
+        component.accessibleContext.accessibleName = "CodeScene CWF initialized ${view.value}"
+    }
+}

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/CwfUiTestDiagnostics.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/CwfUiTestDiagnostics.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 
 private fun isUiTestDiagnosticsEnabled(): Boolean =
-    System.getProperty("codescene.uiTestDiagnostics").equals("true", ignoreCase = true)
+    "true".equals(System.getProperty("codescene.uiTestDiagnostics"), ignoreCase = true)
 
 /**
  * Marks the JCEF Swing component for [view] with a stable name/accessibleName so that


### PR DESCRIPTION
Makes the CodeScene tool window more reliable and observable in UI-test runner sandboxes.

Changes:
- Marks `HomeToolWindowFactory` as `DumbAware` so the tool window shell can render during IntelliJ indexing/dumb mode.
- Adds a property-gated UI-test diagnostic marker when a CWF webview reports initialization through `handleInit`.
- The marker is enabled only with `-Dcodescene.uiTestDiagnostics=true`.
- No visible UI change.
- No behavior change in normal runtime.

Why:
- Existing UI tests can verify that the CodeScene stripe/tool window/JCEF shell exists.
- That does not prove the CWF webapp actually bootstrapped.
- `handleInit` is the plugin-side signal that the CWF app called the IDE bridge.
- The `DumbAware` change reduces startup/indexing interference in UI test sandboxes.

Validation:
- `ktlintCheck compileKotlin buildPlugin`
- Built `build/distributions/CodeScene-0.5.1.zip`
- Verified from `jetbrains-plugin-tests` against that ZIP:
  - `PluginSmokeTest`
  - `CodeSceneToolWindowActivationTest` including new CWF HOME initialization check
  - `CodeSceneAceStatusWidgetTest`
- Full `scripts/run-ui-tests.sh` passed against the rebased PR branch.

Known caveat:
- ACE status-widget tests have shown occasional startup/readiness flakiness and should be stabilized separately.
- The new CWF HOME initialization check passed consistently.
