### PR TITLE
CS-11200: Store ACE auth token in PasswordSafe

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/ISettingsChangeListener.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/ISettingsChangeListener.kt
@@ -6,5 +6,6 @@ fun interface ISettingsChangeListener {
     fun onSettingsChanged(
         oldState: CodeSceneGlobalSettings,
         newState: CodeSceneGlobalSettings,
+        aceAuthTokenChanged: Boolean,
     )
 }

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/ISettingsProvider.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/ISettingsProvider.kt
@@ -6,6 +6,10 @@ import com.codescene.jetbrains.core.models.settings.CodeSceneGlobalSettings
 interface ISettingsProvider {
     fun currentState(): CodeSceneGlobalSettings
 
+    fun getAceAuthToken(): String
+
+    fun setAceAuthToken(token: String)
+
     fun updateTelemetryConsent(hasAccepted: Boolean)
 
     fun updateTelemetryNoticeShown(shown: Boolean)

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/models/settings/CodeSceneGlobalSettings.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/models/settings/CodeSceneGlobalSettings.kt
@@ -28,7 +28,7 @@ data class CodeSceneGlobalSettings(
     var aceStatus: AceStatus = AceStatus.DEACTIVATED,
     var enableCodeLenses: Boolean = true,
     var enableAutoRefactor: Boolean = true,
-    var aceAuthToken: String = "",
+    var aceTokenConfigured: Boolean = false,
     // This is a freemium flag for the Code Health Monitor. If a proper CHM feature flag becomes necessary, use the same approach as ACE and CWF. If not,
     // TODO delete this after the integration with core is complete.
     val codeHealthMonitorEnabled: Boolean = true,

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/review/AcePreflightOrchestrator.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/review/AcePreflightOrchestrator.kt
@@ -19,7 +19,7 @@ class AcePreflightOrchestrator(
         val decision =
             resolveAcePreflightDecision(
                 autoRefactorEnabled = settings.enableAutoRefactor,
-                token = settings.aceAuthToken,
+                token = settingsProvider.getAceAuthToken(),
                 force = force,
             )
 

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/settings/SettingsStateManager.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/settings/SettingsStateManager.kt
@@ -51,6 +51,12 @@ class SettingsStateManager {
         notifyListeners(oldState, extensionSettingsState.copy())
     }
 
+    fun updateAceTokenConfigured(configured: Boolean) {
+        val oldState = extensionSettingsState.copy()
+        extensionSettingsState.aceTokenConfigured = configured
+        notifyListeners(oldState, extensionSettingsState.copy())
+    }
+
     fun addSettingsChangeListener(listener: ISettingsChangeListener) {
         listeners += listener
     }
@@ -59,17 +65,21 @@ class SettingsStateManager {
         listeners -= listener
     }
 
-    fun notifyIfStateChanged(oldState: CodeSceneGlobalSettings) {
+    fun notifyIfStateChanged(
+        oldState: CodeSceneGlobalSettings,
+        aceAuthTokenChanged: Boolean = false,
+    ) {
         val newState = extensionSettingsState.copy()
-        if (oldState != newState) {
-            notifyListeners(oldState, newState)
+        if (oldState != newState || aceAuthTokenChanged) {
+            notifyListeners(oldState, newState, aceAuthTokenChanged)
         }
     }
 
     private fun notifyListeners(
         oldState: CodeSceneGlobalSettings,
         newState: CodeSceneGlobalSettings,
+        aceAuthTokenChanged: Boolean = false,
     ) {
-        listeners.forEach { it.onSettingsChanged(oldState, newState) }
+        listeners.forEach { it.onSettingsChanged(oldState, newState, aceAuthTokenChanged) }
     }
 }

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/util/AutoRefactorConfigUtils.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/util/AutoRefactorConfigUtils.kt
@@ -14,7 +14,7 @@ fun mapAceStatusToCwfString(status: AceStatus): String =
     }
 
 fun toAutoRefactorConfig(settings: CodeSceneGlobalSettings): AutoRefactorConfig {
-    val hasToken = settings.aceAuthToken.trim().isNotEmpty()
+    val hasToken = settings.aceTokenConfigured
     val isActivated = !(!settings.aceAcknowledged && hasToken)
     return AutoRefactorConfig(
         activated = isActivated,

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/util/SettingsChangeAction.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/util/SettingsChangeAction.kt
@@ -14,6 +14,7 @@ sealed class SettingsChangeAction {
 fun resolveSettingsChangeActions(
     oldState: CodeSceneGlobalSettings,
     newState: CodeSceneGlobalSettings,
+    aceAuthTokenChanged: Boolean = false,
 ): List<SettingsChangeAction> {
     val actions = mutableListOf<SettingsChangeAction>()
 
@@ -30,7 +31,7 @@ fun resolveSettingsChangeActions(
         actions.add(SettingsChangeAction.RefreshAceUI(newState.enableAutoRefactor))
     }
 
-    if (oldState.aceAuthToken != newState.aceAuthToken) {
+    if (oldState.aceTokenConfigured != newState.aceTokenConfigured || aceAuthTokenChanged) {
         actions.add(SettingsChangeAction.RefreshAceUI(true))
     }
 

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/AcePreflightOrchestratorTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/AcePreflightOrchestratorTest.kt
@@ -32,14 +32,16 @@ class AcePreflightOrchestratorTest {
         settings: CodeSceneGlobalSettings =
             CodeSceneGlobalSettings(
                 enableAutoRefactor = true,
-                aceAuthToken = "token",
+                aceTokenConfigured = true,
             ),
+        aceAuthToken: String = "token",
         fetchResult: suspend (Boolean) -> TimedResult<PreflightResponse?> = { bypassCache ->
             fetchBypassCache = bypassCache
             TimedResult(preflightResponse, 100)
         },
     ) = AcePreflightOrchestrator(
-        settingsProvider = InMemorySettingsProvider(settings).also { settingsProvider = it },
+        settingsProvider =
+            InMemorySettingsProvider(settings, aceAuthToken = aceAuthToken).also { settingsProvider = it },
         logger = TestLogger,
         serviceName = "Test",
         fetchPreflight = fetchResult,
@@ -57,7 +59,7 @@ class AcePreflightOrchestratorTest {
     @Test
     fun `runPreflight returns null when auto-refactor disabled`() =
         runBlocking {
-            val settings = CodeSceneGlobalSettings(enableAutoRefactor = false, aceAuthToken = "token")
+            val settings = CodeSceneGlobalSettings(enableAutoRefactor = false, aceTokenConfigured = true)
             val orchestrator = createOrchestrator(settings = settings)
             val result = orchestrator.runPreflight()
             assertNull(result)
@@ -90,8 +92,8 @@ class AcePreflightOrchestratorTest {
     @Test
     fun `runPreflight calls onStatusChange with SIGNED_OUT on forced success without token`() =
         runBlocking {
-            val settings = CodeSceneGlobalSettings(enableAutoRefactor = true, aceAuthToken = "")
-            val orchestrator = createOrchestrator(settings = settings)
+            val settings = CodeSceneGlobalSettings(enableAutoRefactor = true, aceTokenConfigured = false)
+            val orchestrator = createOrchestrator(settings = settings, aceAuthToken = "")
             orchestrator.runPreflight(force = true)
             assertTrue(statusChanges.contains(AceStatus.SIGNED_OUT))
         }

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/settings/SettingsStateManagerTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/settings/SettingsStateManagerTest.kt
@@ -70,22 +70,22 @@ class SettingsStateManagerTest {
     fun `updateTelemetryConsent updates state and notifies listeners`() {
         manager.updateTelemetryConsent(true)
         assertTrue(manager.getState().telemetryConsentGiven)
-        verify(exactly = 1) { listener.onSettingsChanged(any(), any()) }
+        verify(exactly = 1) { listener.onSettingsChanged(any(), any(), any()) }
 
         manager.updateTelemetryConsent(false)
         assertFalse(manager.getState().telemetryConsentGiven)
-        verify(exactly = 2) { listener.onSettingsChanged(any(), any()) }
+        verify(exactly = 2) { listener.onSettingsChanged(any(), any(), any()) }
     }
 
     @Test
     fun `updateTelemetryNoticeShown updates state and notifies listeners`() {
         manager.updateTelemetryNoticeShown(true)
         assertTrue(manager.getState().telemetryNoticeShown)
-        verify(exactly = 1) { listener.onSettingsChanged(any(), any()) }
+        verify(exactly = 1) { listener.onSettingsChanged(any(), any(), any()) }
 
         manager.updateTelemetryNoticeShown(false)
         assertFalse(manager.getState().telemetryNoticeShown)
-        verify(exactly = 2) { listener.onSettingsChanged(any(), any()) }
+        verify(exactly = 2) { listener.onSettingsChanged(any(), any(), any()) }
     }
 
     @Test
@@ -94,7 +94,7 @@ class SettingsStateManagerTest {
 
         manager.loadState(newState)
 
-        verify(exactly = 1) { listener.onSettingsChanged(any(), any()) }
+        verify(exactly = 1) { listener.onSettingsChanged(any(), any(), any()) }
         assertEquals("https://custom.example.com", manager.getState().serverUrl)
     }
 
@@ -104,7 +104,7 @@ class SettingsStateManagerTest {
 
         manager.loadState(CodeSceneGlobalSettings(serverUrl = "https://other.com"))
 
-        verify(exactly = 0) { listener.onSettingsChanged(any(), any()) }
+        verify(exactly = 0) { listener.onSettingsChanged(any(), any(), any()) }
     }
 
     @Test
@@ -112,7 +112,7 @@ class SettingsStateManagerTest {
         manager.updateAceStatus(AceStatus.SIGNED_IN)
 
         assertEquals(AceStatus.SIGNED_IN, manager.getState().aceStatus)
-        verify(exactly = 1) { listener.onSettingsChanged(any(), any()) }
+        verify(exactly = 1) { listener.onSettingsChanged(any(), any(), any()) }
     }
 
     @Test
@@ -122,7 +122,7 @@ class SettingsStateManagerTest {
         manager.updateAceAcknowledged(true)
 
         assertTrue(manager.getState().aceAcknowledged)
-        verify(exactly = 1) { listener.onSettingsChanged(any(), any()) }
+        verify(exactly = 1) { listener.onSettingsChanged(any(), any(), any()) }
     }
 
     @Test
@@ -131,7 +131,7 @@ class SettingsStateManagerTest {
 
         manager.notifyIfStateChanged(snapshot)
 
-        verify(exactly = 0) { listener.onSettingsChanged(any(), any()) }
+        verify(exactly = 0) { listener.onSettingsChanged(any(), any(), any()) }
     }
 
     @Test
@@ -141,7 +141,7 @@ class SettingsStateManagerTest {
 
         manager.notifyIfStateChanged(snapshot)
 
-        verify(exactly = 1) { listener.onSettingsChanged(any(), any()) }
+        verify(exactly = 1) { listener.onSettingsChanged(any(), any(), any()) }
     }
 
     @Test
@@ -151,7 +151,7 @@ class SettingsStateManagerTest {
 
         manager.updateAceStatus(AceStatus.ERROR)
 
-        verify(exactly = 1) { listener.onSettingsChanged(any(), any()) }
-        verify(exactly = 1) { second.onSettingsChanged(any(), any()) }
+        verify(exactly = 1) { listener.onSettingsChanged(any(), any(), any()) }
+        verify(exactly = 1) { second.onSettingsChanged(any(), any(), any()) }
     }
 }

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/settings/SettingsStateManagerTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/settings/SettingsStateManagerTest.kt
@@ -126,6 +126,21 @@ class SettingsStateManagerTest {
     }
 
     @Test
+    fun `updateAceTokenConfigured notifies listeners and updates state`() {
+        assertFalse(manager.getState().aceTokenConfigured)
+
+        manager.updateAceTokenConfigured(true)
+
+        assertTrue(manager.getState().aceTokenConfigured)
+        verify(exactly = 1) { listener.onSettingsChanged(any(), any(), any()) }
+
+        manager.updateAceTokenConfigured(false)
+
+        assertFalse(manager.getState().aceTokenConfigured)
+        verify(exactly = 2) { listener.onSettingsChanged(any(), any(), any()) }
+    }
+
+    @Test
     fun `notifyIfStateChanged does nothing when state is unchanged`() {
         val snapshot = manager.currentState().copy()
 

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/InMemorySettingsProvider.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/InMemorySettingsProvider.kt
@@ -6,8 +6,16 @@ import com.codescene.jetbrains.core.models.settings.CodeSceneGlobalSettings
 
 class InMemorySettingsProvider(
     private var settings: CodeSceneGlobalSettings = CodeSceneGlobalSettings(),
+    private var aceAuthToken: String = "",
 ) : ISettingsProvider {
     override fun currentState(): CodeSceneGlobalSettings = settings
+
+    override fun getAceAuthToken(): String = aceAuthToken
+
+    override fun setAceAuthToken(token: String) {
+        aceAuthToken = token
+        settings = settings.copy(aceTokenConfigured = token.isNotBlank())
+    }
 
     override fun updateTelemetryConsent(hasAccepted: Boolean) {
         settings = settings.copy(telemetryConsentGiven = hasAccepted)
@@ -18,7 +26,7 @@ class InMemorySettingsProvider(
     }
 
     override fun updateAceStatus(status: AceStatus) {
-        settings.aceStatus = status
+        settings = settings.copy(aceStatus = status)
     }
 
     override fun updateAceAcknowledged(acknowledged: Boolean) {

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/util/AutoRefactorConfigUtilsTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/util/AutoRefactorConfigUtilsTest.kt
@@ -12,13 +12,13 @@ class AutoRefactorConfigUtilsTest {
     fun `toAutoRefactorConfig activated true when acknowledged`() {
         val withToken =
             toAutoRefactorConfig(
-                CodeSceneGlobalSettings(aceAcknowledged = true, aceAuthToken = "token"),
+                CodeSceneGlobalSettings(aceAcknowledged = true, aceTokenConfigured = true),
             )
         assertTrue(withToken.activated)
 
         val withoutToken =
             toAutoRefactorConfig(
-                CodeSceneGlobalSettings(aceAcknowledged = true, aceAuthToken = ""),
+                CodeSceneGlobalSettings(aceAcknowledged = true, aceTokenConfigured = false),
             )
         assertTrue(withoutToken.activated)
     }
@@ -27,7 +27,7 @@ class AutoRefactorConfigUtilsTest {
     fun `toAutoRefactorConfig activated false when unacknowledged and token present`() {
         val result =
             toAutoRefactorConfig(
-                CodeSceneGlobalSettings(aceAcknowledged = false, aceAuthToken = "token"),
+                CodeSceneGlobalSettings(aceAcknowledged = false, aceTokenConfigured = true),
             )
         assertFalse(result.activated)
     }
@@ -36,15 +36,9 @@ class AutoRefactorConfigUtilsTest {
     fun `toAutoRefactorConfig activated true when unacknowledged and no token`() {
         val result =
             toAutoRefactorConfig(
-                CodeSceneGlobalSettings(aceAcknowledged = false, aceAuthToken = ""),
+                CodeSceneGlobalSettings(aceAcknowledged = false, aceTokenConfigured = false),
             )
         assertTrue(result.activated)
-
-        val blankToken =
-            toAutoRefactorConfig(
-                CodeSceneGlobalSettings(aceAcknowledged = false, aceAuthToken = "   "),
-            )
-        assertTrue(blankToken.activated)
     }
 
     @Test
@@ -57,8 +51,8 @@ class AutoRefactorConfigUtilsTest {
     }
 
     @Test
-    fun `toAutoRefactorConfig disabled is true when token is blank`() {
-        val result = toAutoRefactorConfig(CodeSceneGlobalSettings(aceAuthToken = "   "))
+    fun `toAutoRefactorConfig disabled is true when token not configured`() {
+        val result = toAutoRefactorConfig(CodeSceneGlobalSettings(aceTokenConfigured = false))
         assertEquals(true, result.disabled)
     }
 
@@ -90,7 +84,7 @@ class AutoRefactorConfigUtilsTest {
             toAutoRefactorConfig(
                 CodeSceneGlobalSettings(
                     aceStatus = AceStatus.SIGNED_IN,
-                    aceAuthToken = "tok",
+                    aceTokenConfigured = true,
                 ),
             )
         assertTrue(result.aceStatus.hasToken)
@@ -103,7 +97,7 @@ class AutoRefactorConfigUtilsTest {
             toAutoRefactorConfig(
                 CodeSceneGlobalSettings(
                     aceStatus = AceStatus.SIGNED_OUT,
-                    aceAuthToken = "",
+                    aceTokenConfigured = false,
                 ),
             )
         assertFalse(result.aceStatus.hasToken)
@@ -116,7 +110,7 @@ class AutoRefactorConfigUtilsTest {
             toAutoRefactorConfig(
                 CodeSceneGlobalSettings(
                     aceStatus = AceStatus.DEACTIVATED,
-                    aceAuthToken = "tok",
+                    aceTokenConfigured = true,
                 ),
             )
         assertEquals("disabled", result.aceStatus.status)
@@ -125,7 +119,7 @@ class AutoRefactorConfigUtilsTest {
     @Test
     fun `autoRefactorConfigForDocsView hides auto refactor for general code health doc`() {
         val settings =
-            CodeSceneGlobalSettings(enableAutoRefactor = true, aceAuthToken = "tok")
+            CodeSceneGlobalSettings(enableAutoRefactor = true, aceTokenConfigured = true)
         val result =
             autoRefactorConfigForDocsView(
                 settings,
@@ -139,7 +133,7 @@ class AutoRefactorConfigUtilsTest {
     @Test
     fun `autoRefactorConfigForDocsView hides auto refactor for code health monitor doc`() {
         val settings =
-            CodeSceneGlobalSettings(enableAutoRefactor = true, aceAuthToken = "tok")
+            CodeSceneGlobalSettings(enableAutoRefactor = true, aceTokenConfigured = true)
         val result =
             autoRefactorConfigForDocsView(
                 settings,
@@ -153,7 +147,7 @@ class AutoRefactorConfigUtilsTest {
     @Test
     fun `autoRefactorConfigForDocsView hides auto refactor when code smell has no refactor target`() {
         val settings =
-            CodeSceneGlobalSettings(enableAutoRefactor = true, aceAuthToken = "tok")
+            CodeSceneGlobalSettings(enableAutoRefactor = true, aceTokenConfigured = true)
         val result =
             autoRefactorConfigForDocsView(
                 settings,
@@ -167,7 +161,7 @@ class AutoRefactorConfigUtilsTest {
     @Test
     fun `autoRefactorConfigForDocsView uses base config when code smell has refactor target`() {
         val settings =
-            CodeSceneGlobalSettings(enableAutoRefactor = true, aceAuthToken = "tok")
+            CodeSceneGlobalSettings(enableAutoRefactor = true, aceTokenConfigured = true)
         val result =
             autoRefactorConfigForDocsView(
                 settings,

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/util/SettingsChangeActionTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/util/SettingsChangeActionTest.kt
@@ -39,11 +39,19 @@ class SettingsChangeActionTest {
     }
 
     @Test
-    fun `returns refresh ace ui when auth token changed`() {
-        val oldState = CodeSceneGlobalSettings(aceAuthToken = "")
-        val newState = oldState.copy(aceAuthToken = "token")
+    fun `returns refresh ace ui when auth token configured flag changed`() {
+        val oldState = CodeSceneGlobalSettings(aceTokenConfigured = false)
+        val newState = oldState.copy(aceTokenConfigured = true)
 
         val result = resolveSettingsChangeActions(oldState, newState)
+
+        assertEquals(listOf(SettingsChangeAction.RefreshAceUI(true)), result)
+    }
+
+    @Test
+    fun `returns refresh ace ui when auth token value changed`() {
+        val state = CodeSceneGlobalSettings(aceTokenConfigured = true)
+        val result = resolveSettingsChangeActions(state, state, aceAuthTokenChanged = true)
 
         assertEquals(listOf(SettingsChangeAction.RefreshAceUI(true)), result)
     }
@@ -54,14 +62,14 @@ class SettingsChangeActionTest {
             CodeSceneGlobalSettings(
                 enableCodeLenses = true,
                 enableAutoRefactor = true,
-                aceAuthToken = "",
+                aceTokenConfigured = false,
                 aceStatus = AceStatus.DEACTIVATED,
             )
         val newState =
             oldState.copy(
                 enableCodeLenses = false,
                 enableAutoRefactor = false,
-                aceAuthToken = "token",
+                aceTokenConfigured = true,
             ).also { it.aceStatus = AceStatus.OFFLINE }
 
         val result = resolveSettingsChangeActions(oldState, newState)

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
@@ -120,7 +120,7 @@ class AceService :
         val (project, editor, request) = params
         val effectiveOptions =
             options ?: RefactoringOptions().apply {
-                setToken(settingsProvider.currentState().aceAuthToken)
+                setToken(settingsProvider.getAceAuthToken())
                 setSkipCache(request.skipCache)
             }
         Log.debug(
@@ -199,7 +199,7 @@ class AceService :
                     ExtensionAPI.refactor(request.function, options)
                 }
             },
-            getToken = { settingsProvider.currentState().aceAuthToken },
+            getToken = { settingsProvider.getAceAuthToken() },
             onStatusChange = { status -> AceEntryOrchestrator.handleAceStatusChange(status) },
             onRequested = { request ->
                 telemetryService.logUsage(

--- a/src/main/kotlin/com/codescene/jetbrains/platform/editor/annotator/CodeSmellAnnotator.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/editor/annotator/CodeSmellAnnotator.kt
@@ -123,7 +123,7 @@ class CodeSmellAnnotator : ExternalAnnotator<
         Log.debug("Creating annotation for code smell '${codeSmell.category}' at range: $range")
 
         val aceAvailable =
-            settings.enableAutoRefactor && settings.aceAuthToken.trim().isNotEmpty()
+            settings.enableAutoRefactor && settings.aceTokenConfigured
         val function =
             if (aceAvailable) {
                 getRefactorableFunction(codeSmell.category, codeSmell.highlightRange.startLine, refactorableFunctions)

--- a/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/providers/AceCodeVisionProvider.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/editor/codeVision/providers/AceCodeVisionProvider.kt
@@ -54,7 +54,7 @@ class AceCodeVisionProvider : CodeVisionProvider<Unit> {
 
         val disabled =
             !settings.enableAutoRefactor ||
-                settings.aceAuthToken.trim().isEmpty() || settings.aceStatus == AceStatus.DEACTIVATED
+                !settings.aceTokenConfigured || settings.aceStatus == AceStatus.DEACTIVATED
         if (disabled) {
             Log.info("Rendering empty code vision providers for file '${editor.virtualFile?.name}'.")
             return CodeVisionState.READY_EMPTY

--- a/src/main/kotlin/com/codescene/jetbrains/platform/listeners/ProjectStartupActivity.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/listeners/ProjectStartupActivity.kt
@@ -70,8 +70,8 @@ class ProjectStartupActivity : ProjectActivity {
         if (!noticeDisplayed) showTelemetryNoticeNotification(project)
 
         val listener =
-            ISettingsChangeListener { oldState, newState ->
-                val actions = resolveSettingsChangeActions(oldState, newState)
+            ISettingsChangeListener { oldState, newState, aceAuthTokenChanged ->
+                val actions = resolveSettingsChangeActions(oldState, newState, aceAuthTokenChanged)
                 actions.forEach { action ->
                     when (action) {
                         is SettingsChangeAction.RefreshCodeVision -> {

--- a/src/main/kotlin/com/codescene/jetbrains/platform/settings/AceAuthTokenStore.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/settings/AceAuthTokenStore.kt
@@ -1,0 +1,23 @@
+package com.codescene.jetbrains.platform.settings
+
+import com.intellij.credentialStore.CredentialAttributes
+import com.intellij.credentialStore.Credentials
+import com.intellij.credentialStore.generateServiceName
+import com.intellij.ide.passwordSafe.PasswordSafe
+
+object AceAuthTokenStore {
+    private val credentialAttributes =
+        CredentialAttributes(generateServiceName("com.codescene.vanilla", "ace-auth-token"))
+
+    fun getToken(): String = PasswordSafe.instance.getPassword(credentialAttributes).orEmpty()
+
+    fun setToken(token: String) {
+        if (token.isBlank()) {
+            PasswordSafe.instance.set(credentialAttributes, null)
+        } else {
+            PasswordSafe.instance.set(credentialAttributes, Credentials("ace", token))
+        }
+    }
+
+    fun hasToken(): Boolean = getToken().isNotBlank()
+}

--- a/src/main/kotlin/com/codescene/jetbrains/platform/settings/CodeSceneGlobalSettingsPersisted.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/settings/CodeSceneGlobalSettingsPersisted.kt
@@ -1,0 +1,54 @@
+package com.codescene.jetbrains.platform.settings
+
+import com.codescene.jetbrains.core.models.settings.AceStatus
+import com.codescene.jetbrains.core.models.settings.CodeSceneGlobalSettings
+import com.codescene.jetbrains.core.models.settings.MonitorTreeSortOptions
+import com.codescene.jetbrains.core.util.Constants.CODESCENE_SERVER_URL
+
+class CodeSceneGlobalSettingsPersisted {
+    var serverUrl: String = CODESCENE_SERVER_URL
+    var aceAcknowledged: Boolean = false
+    var previewCodeHealthGate: Boolean = false
+    var telemetryConsentGiven: Boolean = true
+    var telemetryNoticeShown: Boolean = false
+    var aceStatus: AceStatus = AceStatus.DEACTIVATED
+    var enableCodeLenses: Boolean = true
+    var enableAutoRefactor: Boolean = true
+    var aceAuthToken: String = ""
+    var aceTokenConfigured: Boolean = false
+    var codeHealthMonitorEnabled: Boolean = true
+    var monitorTreeSortOption: MonitorTreeSortOptions = MonitorTreeSortOptions.SCORE_ASCENDING
+    var version: Int? = null
+}
+
+fun CodeSceneGlobalSettingsPersisted.toCore(): CodeSceneGlobalSettings =
+    CodeSceneGlobalSettings(
+        serverUrl = serverUrl,
+        aceAcknowledged = aceAcknowledged,
+        previewCodeHealthGate = previewCodeHealthGate,
+        telemetryConsentGiven = telemetryConsentGiven,
+        telemetryNoticeShown = telemetryNoticeShown,
+        aceStatus = aceStatus,
+        enableCodeLenses = enableCodeLenses,
+        enableAutoRefactor = enableAutoRefactor,
+        aceTokenConfigured = aceTokenConfigured,
+        codeHealthMonitorEnabled = codeHealthMonitorEnabled,
+        monitorTreeSortOption = monitorTreeSortOption,
+        version = version,
+    )
+
+fun CodeSceneGlobalSettings.toPersisted(): CodeSceneGlobalSettingsPersisted =
+    CodeSceneGlobalSettingsPersisted().also { persisted ->
+        persisted.serverUrl = serverUrl
+        persisted.aceAcknowledged = aceAcknowledged
+        persisted.previewCodeHealthGate = previewCodeHealthGate
+        persisted.telemetryConsentGiven = telemetryConsentGiven
+        persisted.telemetryNoticeShown = telemetryNoticeShown
+        persisted.aceStatus = aceStatus
+        persisted.enableCodeLenses = enableCodeLenses
+        persisted.enableAutoRefactor = enableAutoRefactor
+        persisted.aceTokenConfigured = aceTokenConfigured
+        persisted.codeHealthMonitorEnabled = codeHealthMonitorEnabled
+        persisted.monitorTreeSortOption = monitorTreeSortOption
+        persisted.version = version
+    }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/settings/CodeSceneGlobalSettingsStore.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/settings/CodeSceneGlobalSettingsStore.kt
@@ -16,16 +16,36 @@ import com.intellij.openapi.components.Storage
     storages = [Storage("codescene-settings.xml")],
 )
 @Service(Service.Level.APP)
-class CodeSceneGlobalSettingsStore : PersistentStateComponent<CodeSceneGlobalSettings>, ISettingsProvider {
+class CodeSceneGlobalSettingsStore : PersistentStateComponent<CodeSceneGlobalSettingsPersisted>, ISettingsProvider {
     private val stateManager = SettingsStateManager()
 
-    override fun getState(): CodeSceneGlobalSettings = stateManager.getState()
+    override fun getState(): CodeSceneGlobalSettingsPersisted {
+        val persisted = stateManager.getState().toPersisted()
+        persisted.aceTokenConfigured = AceAuthTokenStore.hasToken()
+        persisted.aceAuthToken = ""
+        return persisted
+    }
 
-    override fun loadState(state: CodeSceneGlobalSettings) {
-        stateManager.loadState(state)
+    override fun loadState(state: CodeSceneGlobalSettingsPersisted) {
+        val legacyToken = state.aceAuthToken.takeIf { it.isNotBlank() }
+        if (legacyToken != null) {
+            AceAuthTokenStore.setToken(legacyToken)
+        }
+        val tokenConfigured = state.aceTokenConfigured || AceAuthTokenStore.hasToken()
+        stateManager.loadState(state.toCore().copy(aceTokenConfigured = tokenConfigured))
     }
 
     override fun currentState(): CodeSceneGlobalSettings = stateManager.currentState()
+
+    override fun getAceAuthToken(): String = AceAuthTokenStore.getToken()
+
+    override fun setAceAuthToken(token: String) {
+        AceAuthTokenStore.setToken(token)
+        stateManager.updateAceTokenConfigured(AceAuthTokenStore.hasToken())
+        ApplicationManager.getApplication().invokeLater {
+            ApplicationManager.getApplication().saveSettings()
+        }
+    }
 
     override fun updateTelemetryConsent(hasAccepted: Boolean) {
         stateManager.updateTelemetryConsent(hasAccepted)
@@ -57,8 +77,12 @@ class CodeSceneGlobalSettingsStore : PersistentStateComponent<CodeSceneGlobalSet
         stateManager.removeSettingsChangeListener(listener)
     }
 
-    fun notifyIfStateChanged(oldState: CodeSceneGlobalSettings) {
-        stateManager.notifyIfStateChanged(oldState)
+    fun notifyIfStateChanged(
+        oldState: CodeSceneGlobalSettings,
+        previousAceAuthToken: String? = null,
+    ) {
+        val tokenChanged = previousAceAuthToken != null && previousAceAuthToken != getAceAuthToken()
+        stateManager.notifyIfStateChanged(oldState, tokenChanged)
     }
 
     companion object {

--- a/src/main/kotlin/com/codescene/jetbrains/platform/settings/CodeSceneGlobalSettingsStore.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/settings/CodeSceneGlobalSettingsStore.kt
@@ -19,20 +19,28 @@ import com.intellij.openapi.components.Storage
 class CodeSceneGlobalSettingsStore : PersistentStateComponent<CodeSceneGlobalSettingsPersisted>, ISettingsProvider {
     private val stateManager = SettingsStateManager()
 
-    override fun getState(): CodeSceneGlobalSettingsPersisted {
-        val persisted = stateManager.getState().toPersisted()
-        persisted.aceTokenConfigured = AceAuthTokenStore.hasToken()
-        persisted.aceAuthToken = ""
-        return persisted
-    }
+    override fun getState(): CodeSceneGlobalSettingsPersisted =
+        stateManager.getState().toPersisted().apply {
+            aceAuthToken = ""
+        }
 
     override fun loadState(state: CodeSceneGlobalSettingsPersisted) {
         val legacyToken = state.aceAuthToken.takeIf { it.isNotBlank() }
-        if (legacyToken != null) {
-            AceAuthTokenStore.setToken(legacyToken)
-        }
-        val tokenConfigured = state.aceTokenConfigured || AceAuthTokenStore.hasToken()
+        val tokenConfigured = state.aceTokenConfigured || legacyToken != null
         stateManager.loadState(state.toCore().copy(aceTokenConfigured = tokenConfigured))
+        if (legacyToken != null) {
+            migrateLegacyAceAuthToken(legacyToken)
+        }
+    }
+
+    private fun migrateLegacyAceAuthToken(legacyToken: String) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            AceAuthTokenStore.setToken(legacyToken)
+            stateManager.updateAceTokenConfigured(true)
+            ApplicationManager.getApplication().invokeLater {
+                ApplicationManager.getApplication().saveSettings()
+            }
+        }
     }
 
     override fun currentState(): CodeSceneGlobalSettings = stateManager.currentState()
@@ -41,7 +49,7 @@ class CodeSceneGlobalSettingsStore : PersistentStateComponent<CodeSceneGlobalSet
 
     override fun setAceAuthToken(token: String) {
         AceAuthTokenStore.setToken(token)
-        stateManager.updateAceTokenConfigured(AceAuthTokenStore.hasToken())
+        stateManager.updateAceTokenConfigured(token.isNotBlank())
         ApplicationManager.getApplication().invokeLater {
             ApplicationManager.getApplication().saveSettings()
         }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/settings/tab/SettingsTab.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/settings/tab/SettingsTab.kt
@@ -12,16 +12,20 @@ import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.panel
+import kotlin.properties.Delegates
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Suppress("DialogTitleCapitalization")
 class SettingsTab : BoundConfigurable(UiLabelsBundle.message("settingsTitle")) {
-    private val settings = CodeSceneGlobalSettingsStore.getInstance().currentState()
+    private val settingsStore = CodeSceneGlobalSettingsStore.getInstance()
+    private val settings = settingsStore.currentState()
     private val scope = CoroutineScope(Dispatchers.IO)
+    private var aceAuthToken by Delegates.observable("") { _, _, _ -> }
 
     override fun createPanel(): DialogPanel {
+        aceAuthToken = settingsStore.getAceAuthToken()
         return panel {
             row {
                 checkBox(UiLabelsBundle.message("enableCodeLenses"))
@@ -50,11 +54,10 @@ class SettingsTab : BoundConfigurable(UiLabelsBundle.message("settingsTitle")) {
                         .align(Align.FILL)
                         .resizableColumn()
                         .comment(UiLabelsBundle.message("aceAuthTokenComment"))
-                        .bindText(settings::aceAuthToken)
+                        .bindText(::aceAuthToken)
                 }
             }
 
-            // TODO: verify naming of this section, currently just a placeholder
             groupRowsRange(UiLabelsBundle.message("cloudConnection")) {
                 row(UiLabelsBundle.message("serverUrl")) {
                     textField()
@@ -83,12 +86,20 @@ class SettingsTab : BoundConfigurable(UiLabelsBundle.message("settingsTitle")) {
         }
     }
 
+    override fun reset() {
+        aceAuthToken = settingsStore.getAceAuthToken()
+        super.reset()
+    }
+
     override fun apply() {
         val previousState = settings.copy()
+        val previousToken = settingsStore.getAceAuthToken()
         super.apply()
-        CodeSceneGlobalSettingsStore.getInstance().notifyIfStateChanged(previousState)
+        settingsStore.setAceAuthToken(aceAuthToken)
+        settingsStore.notifyIfStateChanged(previousState, previousToken)
         val onlyTelemetryConsentChanged =
-            previousState.copy(telemetryConsentGiven = settings.telemetryConsentGiven) == settings
+            previousState.copy(telemetryConsentGiven = settings.telemetryConsentGiven) == settings &&
+                previousToken == aceAuthToken
         if (!onlyTelemetryConsentChanged) {
             scope.launch {
                 AceService.getInstance().runPreflight(true)

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceCwfHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceCwfHandler.kt
@@ -37,27 +37,32 @@ class AceCwfHandler(private val project: Project) {
         fnToRefactor: FnToRefactor? = null,
     ) {
         if (fnToRefactor != null) {
-            ApplicationManager.getApplication().invokeLater {
-                val editor = getSelectedTextEditor(project, fileData.fileName)
-                val language = editor?.virtualFile?.extension
-                aceEntryOrchestrator.handleAceEntryPoint(
-                    RefactoringParams(
-                        project = project,
-                        editor = editor,
-                        request =
-                            com.codescene.jetbrains.core.models.RefactoringRequest(
-                                filePath = fileData.fileName,
-                                language = language,
-                                function = fnToRefactor,
-                                source = source,
-                            ),
-                    ),
-                )
+            ApplicationManager.getApplication().executeOnPooledThread {
+                val token = appServices.settingsProvider.getAceAuthToken()
+                ApplicationManager.getApplication().invokeLater {
+                    val editor = getSelectedTextEditor(project, fileData.fileName)
+                    val language = editor?.virtualFile?.extension
+                    aceEntryOrchestrator.handleAceEntryPoint(
+                        RefactoringParams(
+                            project = project,
+                            editor = editor,
+                            request =
+                                com.codescene.jetbrains.core.models.RefactoringRequest(
+                                    filePath = fileData.fileName,
+                                    language = language,
+                                    function = fnToRefactor,
+                                    source = source,
+                                ),
+                        ),
+                        aceAuthToken = token,
+                    )
+                }
             }
             return
         }
 
         ApplicationManager.getApplication().executeOnPooledThread {
+            val token = appServices.settingsProvider.getAceAuthToken()
             val bufferContent = resolveFileContent(fileData.fileName)
             val request =
                 resolveRefactoringRequest(
@@ -73,13 +78,16 @@ class AceCwfHandler(private val project: Project) {
             val language = editor?.virtualFile?.extension
             val requestWithLanguage = request.copy(language = language)
 
-            aceEntryOrchestrator.handleAceEntryPoint(
-                RefactoringParams(
-                    project = project,
-                    editor = editor,
-                    request = requestWithLanguage,
-                ),
-            )
+            ApplicationManager.getApplication().invokeLater {
+                aceEntryOrchestrator.handleAceEntryPoint(
+                    RefactoringParams(
+                        project = project,
+                        editor = editor,
+                        request = requestWithLanguage,
+                    ),
+                    aceAuthToken = token,
+                )
+            }
         }
     }
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
@@ -98,7 +98,7 @@ class AceEntryOrchestrator(private val project: Project) {
 
     private fun createRefactoringOptions(skipCache: Boolean) =
         RefactoringOptions().apply {
-            setToken(appServices.settingsProvider.currentState().aceAuthToken)
+            setToken(appServices.settingsProvider.getAceAuthToken())
             setSkipCache(skipCache)
         }
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceEntryOrchestrator.kt
@@ -28,6 +28,7 @@ import com.codescene.jetbrains.platform.webview.WebViewInitializer
 import com.codescene.jetbrains.platform.webview.util.OpenAceAcknowledgementParams
 import com.codescene.jetbrains.platform.webview.util.openAceAcknowledgeView
 import com.codescene.jetbrains.platform.webview.util.openAceWindow
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
@@ -75,7 +76,10 @@ class AceEntryOrchestrator(private val project: Project) {
         }
     }
 
-    fun handleAceEntryPoint(params: RefactoringParams) {
+    fun handleAceEntryPoint(
+        params: RefactoringParams,
+        aceAuthToken: String? = null,
+    ) {
         val (_, editor, request) = params
         editor ?: return
 
@@ -87,20 +91,39 @@ class AceEntryOrchestrator(private val project: Project) {
             )
         when (command) {
             is AceEntryCommand.Skip -> Log.warn("Cannot use ACE as it is disabled.")
-            is AceEntryCommand.StartRefactor -> {
-                val options = createRefactoringOptions(command.skipCache)
-                AceService.getInstance().refactor(params, options)
-            }
+            is AceEntryCommand.StartRefactor -> startRefactor(params, command.skipCache, aceAuthToken)
             is AceEntryCommand.OpenAcknowledgement ->
                 handleOpenAceAcknowledgement(editor, command.function, command.source)
         }
     }
 
-    private fun createRefactoringOptions(skipCache: Boolean) =
-        RefactoringOptions().apply {
-            setToken(appServices.settingsProvider.getAceAuthToken())
-            setSkipCache(skipCache)
+    private fun startRefactor(
+        params: RefactoringParams,
+        skipCache: Boolean,
+        aceAuthToken: String? = null,
+    ) {
+        fun runRefactor(token: String) {
+            ApplicationManager.getApplication().invokeLater {
+                AceService.getInstance().refactor(params, createRefactoringOptions(token, skipCache))
+            }
         }
+        val token = aceAuthToken
+        if (token != null) {
+            runRefactor(token)
+            return
+        }
+        ApplicationManager.getApplication().executeOnPooledThread {
+            runRefactor(appServices.settingsProvider.getAceAuthToken())
+        }
+    }
+
+    private fun createRefactoringOptions(
+        token: String,
+        skipCache: Boolean,
+    ) = RefactoringOptions().apply {
+        setToken(token)
+        setSkipCache(skipCache)
+    }
 
     fun handleOpenAceAcknowledgement(
         editor: Editor,


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rppky (CS-11200)

## Problem
The ACE auth token was serialized in cleartext in `codescene-settings.xml`. Anyone with same-user filesystem access could read it and impersonate the user against the ACE backend.

## Fix
- Store the token in IntelliJ `PasswordSafe` (service `com.codescene.vanilla` / `ace-auth-token`).
- Persist only `aceTokenConfigured` in settings XML; migrate legacy `aceAuthToken` on first load and clear it from disk.
- Expose token via `ISettingsProvider.getAceAuthToken` / `setAceAuthToken`; settings UI reads/writes through the secure store.

## Test plan
- [x] Fresh install: enter token in Settings, confirm `codescene-settings.xml` has no token value
- [x] Upgrade from build with plaintext token: token still works after restart; XML field cleared after save
- [x] Clear token: ACE UI disables as before
- [x] `gradlew` format/check + test passed; CodeScene MCP (`analyze_change_set`, per-file reviews) run

Made with [Cursor](https://cursor.com)