### PR TITLE
CS-11202: Restrict CWF bridge to project-local file paths

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
@@ -86,7 +86,7 @@ internal fun isRealPathUnderAllowedRoot(
 private fun isRejectedCwfFilePathInput(trimmed: String): Boolean =
     trimmed.isEmpty() || trimmed.indexOf('\u0000') >= 0 || trimmed.lowercase().startsWith("file:")
 
-private fun parseCwfPath(trimmed: String): Path? =
+internal fun parseCwfPath(trimmed: String): Path? =
     try {
         Paths.get(trimmed)
     } catch (_: InvalidPathException) {

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
@@ -56,7 +56,7 @@ fun resolveCopyAction(
 
 fun isUrlAllowed(url: String): Boolean = url.isNotBlank() && ALLOWED_DOMAINS.any { url.startsWith(it) }
 
-private fun resolveRealPathString(path: Path): String? =
+internal fun resolveRealPathString(path: Path): String? =
     try {
         path.toRealPath().toString()
     } catch (_: IOException) {
@@ -65,7 +65,7 @@ private fun resolveRealPathString(path: Path): String? =
         null
     }
 
-private fun isRealPathUnderAllowedRoot(
+internal fun isRealPathUnderAllowedRoot(
     candidatePath: Path,
     root: String,
 ): Boolean {
@@ -97,13 +97,7 @@ private fun isAbsoluteCwfPathAllowed(
     path: Path,
     allowedRoots: Collection<String>,
 ): Boolean {
-    val absolute =
-        try {
-            path.toAbsolutePath()
-        } catch (_: InvalidPathException) {
-            return false
-        }
-    return allowedRoots.any { root -> isRealPathUnderAllowedRoot(absolute, root) }
+    return allowedRoots.any { root -> isRealPathUnderAllowedRoot(path.toAbsolutePath(), root) }
 }
 
 private fun isRelativeCwfPathAllowed(

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
@@ -7,6 +7,9 @@ import com.codescene.jetbrains.core.models.view.AceData
 import com.codescene.jetbrains.core.models.view.DocsData
 import com.codescene.jetbrains.core.util.Constants.ALLOWED_DOMAINS
 import com.codescene.jetbrains.core.util.TelemetryEvents
+import java.io.IOException
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
 import java.nio.file.Paths
 
 data class ApplyAction(
@@ -53,6 +56,33 @@ fun resolveCopyAction(
 
 fun isUrlAllowed(url: String): Boolean = url.isNotBlank() && ALLOWED_DOMAINS.any { url.startsWith(it) }
 
+private fun resolveRealPathString(path: Path): String? =
+    try {
+        path.toRealPath().toString()
+    } catch (_: IOException) {
+        null
+    } catch (_: SecurityException) {
+        null
+    }
+
+private fun isRealPathUnderAllowedRoot(
+    candidatePath: Path,
+    root: String,
+): Boolean {
+    if (root.isBlank()) {
+        return false
+    }
+    val rootPath =
+        try {
+            Paths.get(root)
+        } catch (_: InvalidPathException) {
+            return false
+        }
+    val realRoot = resolveRealPathString(rootPath) ?: return false
+    val realTarget = resolveRealPathString(candidatePath) ?: return false
+    return isPathUnderRoot(realTarget, realRoot)
+}
+
 fun isCwfLocalFilePathAllowed(
     filePath: String,
     allowedRoots: Collection<String>,
@@ -66,18 +96,31 @@ fun isCwfLocalFilePathAllowed(
         return false
     }
 
-    val path = Paths.get(trimmed)
+    val path =
+        try {
+            Paths.get(trimmed)
+        } catch (_: InvalidPathException) {
+            return false
+        }
+
     if (path.isAbsolute || trimmed.startsWith("/")) {
-        val normalized = path.toAbsolutePath().normalize().toString()
-        return allowedRoots.any { root -> root.isNotBlank() && isPathUnderRoot(normalized, root) }
+        val absolute =
+            try {
+                path.toAbsolutePath()
+            } catch (_: InvalidPathException) {
+                return false
+            }
+        return allowedRoots.any { root -> isRealPathUnderAllowedRoot(absolute, root) }
     }
 
     return allowedRoots.any { root ->
-        if (root.isBlank()) {
-            return@any false
-        }
-        val resolved = Paths.get(root, trimmed).normalize().toAbsolutePath().toString()
-        isPathUnderRoot(resolved, root)
+        val combined =
+            try {
+                Paths.get(root, trimmed).toAbsolutePath().normalize()
+            } catch (_: InvalidPathException) {
+                return@any false
+            }
+        isRealPathUnderAllowedRoot(combined, root)
     }
 }
 

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
@@ -83,37 +83,34 @@ private fun isRealPathUnderAllowedRoot(
     return isPathUnderRoot(realTarget, realRoot)
 }
 
-fun isCwfLocalFilePathAllowed(
-    filePath: String,
-    allowedRoots: Collection<String>,
-): Boolean {
-    val trimmed = filePath.trim()
-    if (trimmed.isEmpty() || trimmed.indexOf('\u0000') >= 0) {
-        return false
-    }
-    val lower = trimmed.lowercase()
-    if (lower.startsWith("file:")) {
-        return false
+private fun isRejectedCwfFilePathInput(trimmed: String): Boolean =
+    trimmed.isEmpty() || trimmed.indexOf('\u0000') >= 0 || trimmed.lowercase().startsWith("file:")
+
+private fun parseCwfPath(trimmed: String): Path? =
+    try {
+        Paths.get(trimmed)
+    } catch (_: InvalidPathException) {
+        null
     }
 
-    val path =
+private fun isAbsoluteCwfPathAllowed(
+    path: Path,
+    allowedRoots: Collection<String>,
+): Boolean {
+    val absolute =
         try {
-            Paths.get(trimmed)
+            path.toAbsolutePath()
         } catch (_: InvalidPathException) {
             return false
         }
+    return allowedRoots.any { root -> isRealPathUnderAllowedRoot(absolute, root) }
+}
 
-    if (path.isAbsolute || trimmed.startsWith("/")) {
-        val absolute =
-            try {
-                path.toAbsolutePath()
-            } catch (_: InvalidPathException) {
-                return false
-            }
-        return allowedRoots.any { root -> isRealPathUnderAllowedRoot(absolute, root) }
-    }
-
-    return allowedRoots.any { root ->
+private fun isRelativeCwfPathAllowed(
+    trimmed: String,
+    allowedRoots: Collection<String>,
+): Boolean =
+    allowedRoots.any { root ->
         val combined =
             try {
                 Paths.get(root, trimmed).toAbsolutePath().normalize()
@@ -121,6 +118,20 @@ fun isCwfLocalFilePathAllowed(
                 return@any false
             }
         isRealPathUnderAllowedRoot(combined, root)
+    }
+
+fun isCwfLocalFilePathAllowed(
+    filePath: String,
+    allowedRoots: Collection<String>,
+): Boolean {
+    val trimmed = filePath.trim()
+    if (isRejectedCwfFilePathInput(trimmed)) {
+        return false
+    }
+    val path = parseCwfPath(trimmed) ?: return false
+    return when {
+        path.isAbsolute || trimmed.startsWith("/") -> isAbsoluteCwfPathAllowed(path, allowedRoots)
+        else -> isRelativeCwfPathAllowed(trimmed, allowedRoots)
     }
 }
 

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
@@ -1,11 +1,13 @@
 package com.codescene.jetbrains.core.handler
 
+import com.codescene.jetbrains.core.git.isPathUnderRoot
 import com.codescene.jetbrains.core.models.message.OpenDocsForFunction
 import com.codescene.jetbrains.core.models.shared.FileMetaType
 import com.codescene.jetbrains.core.models.view.AceData
 import com.codescene.jetbrains.core.models.view.DocsData
 import com.codescene.jetbrains.core.util.Constants.ALLOWED_DOMAINS
 import com.codescene.jetbrains.core.util.TelemetryEvents
+import java.nio.file.Paths
 
 data class ApplyAction(
     val filePath: String,
@@ -50,6 +52,34 @@ fun resolveCopyAction(
 }
 
 fun isUrlAllowed(url: String): Boolean = url.isNotBlank() && ALLOWED_DOMAINS.any { url.startsWith(it) }
+
+fun isCwfLocalFilePathAllowed(
+    filePath: String,
+    allowedRoots: Collection<String>,
+): Boolean {
+    val trimmed = filePath.trim()
+    if (trimmed.isEmpty() || trimmed.indexOf('\u0000') >= 0) {
+        return false
+    }
+    val lower = trimmed.lowercase()
+    if (lower.startsWith("file:")) {
+        return false
+    }
+
+    val path = Paths.get(trimmed)
+    if (path.isAbsolute || trimmed.startsWith("/")) {
+        val normalized = path.toAbsolutePath().normalize().toString()
+        return allowedRoots.any { root -> root.isNotBlank() && isPathUnderRoot(normalized, root) }
+    }
+
+    return allowedRoots.any { root ->
+        if (root.isBlank()) {
+            return@any false
+        }
+        val resolved = Paths.get(root, trimmed).normalize().toAbsolutePath().toString()
+        isPathUnderRoot(resolved, root)
+    }
+}
 
 fun toDocsData(docsForFunction: OpenDocsForFunction): DocsData =
     DocsData(

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
@@ -15,7 +15,6 @@ import com.codescene.jetbrains.core.models.view.RefactoringProperties
 import com.codescene.jetbrains.core.util.TelemetryEvents
 import io.mockk.every
 import io.mockk.mockk
-import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
 import org.junit.Assert.assertEquals
@@ -23,7 +22,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assume.assumeTrue
 import org.junit.Test
 
 class CwfActionLogicTest {
@@ -142,16 +140,18 @@ class CwfActionLogicTest {
     }
 
     @Test
-    fun `isRealPathUnderAllowedRoot returns false when root cannot be parsed`() {
+    fun `parseCwfPath returns null when path string is not valid`() {
+        assertNull(parseCwfPath("bad\u0000file.kt"))
+    }
+
+    @Test
+    fun `isCwfLocalFilePathAllowed fails closed for invalid root path syntax`() {
         val root = createCwfGuardRoot()
-        val candidate = Paths.get(writeFileUnderRoot(root, "f.kt"))
+        val file = Paths.get(writeFileUnderRoot(root, "ok.kt"))
         val invalidRoot = invalidRootForPathsGet()
-        try {
-            Paths.get(invalidRoot)
-            assumeTrue("Paths.get accepted invalid root on this OS", false)
-        } catch (_: InvalidPathException) {
-            assertFalse(isRealPathUnderAllowedRoot(candidate, invalidRoot))
-        }
+
+        assertFalse(isRealPathUnderAllowedRoot(file, invalidRoot))
+        assertFalse(isCwfLocalFilePathAllowed("ok.kt", listOf(invalidRoot)))
     }
 
     @Test
@@ -159,18 +159,12 @@ class CwfActionLogicTest {
         val root = createCwfGuardRoot()
         val absolute = writeFileUnderRoot(root, "Abs.kt")
         assertTrue(isCwfLocalFilePathAllowed(Paths.get(absolute).toAbsolutePath().toString(), listOf(root)))
-        val invalidRoot = invalidRootForPathsGet()
-        try {
-            Paths.get(invalidRoot)
-            assumeTrue("Paths.get accepted invalid root on this OS", false)
-        } catch (_: InvalidPathException) {
-            assertFalse(
-                isCwfLocalFilePathAllowed(
-                    Paths.get(absolute).toAbsolutePath().toString(),
-                    listOf(invalidRoot),
-                ),
-            )
-        }
+        assertFalse(
+            isCwfLocalFilePathAllowed(
+                Paths.get(absolute).toAbsolutePath().toString(),
+                listOf(invalidRootForPathsGet()),
+            ),
+        )
     }
 
     @Test

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
@@ -15,16 +15,15 @@ import com.codescene.jetbrains.core.models.view.RefactoringProperties
 import com.codescene.jetbrains.core.util.TelemetryEvents
 import io.mockk.every
 import io.mockk.mockk
-import java.io.File
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
-import org.junit.Assume.assumeTrue
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 
 class CwfActionLogicTest {
@@ -110,7 +109,13 @@ class CwfActionLogicTest {
         val roots = listOf(root)
 
         val outsideRoot =
-            Paths.get(root).resolveSibling("cwf-guard-outside").resolve("secret.txt").toAbsolutePath().normalize().toString()
+            Paths
+                .get(root)
+                .resolveSibling("cwf-guard-outside")
+                .resolve("secret.txt")
+                .toAbsolutePath()
+                .normalize()
+                .toString()
 
         assertFalse(isCwfLocalFilePathAllowed("", roots))
         assertFalse(isCwfLocalFilePathAllowed("file:///etc/passwd", roots))
@@ -159,7 +164,12 @@ class CwfActionLogicTest {
             Paths.get(invalidRoot)
             assumeTrue("Paths.get accepted invalid root on this OS", false)
         } catch (_: InvalidPathException) {
-            assertFalse(isCwfLocalFilePathAllowed(Paths.get(absolute).toAbsolutePath().toString(), listOf(invalidRoot)))
+            assertFalse(
+                isCwfLocalFilePathAllowed(
+                    Paths.get(absolute).toAbsolutePath().toString(),
+                    listOf(invalidRoot),
+                ),
+            )
         }
     }
 

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
@@ -13,8 +13,13 @@ import com.codescene.jetbrains.core.models.view.RecommendedAction
 import com.codescene.jetbrains.core.models.view.RefactorResponse
 import com.codescene.jetbrains.core.models.view.RefactoringProperties
 import com.codescene.jetbrains.core.util.TelemetryEvents
+import io.mockk.every
+import io.mockk.mockk
 import java.io.File
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
 import java.nio.file.Paths
+import org.junit.Assume.assumeTrue
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -101,29 +106,71 @@ class CwfActionLogicTest {
 
     @Test
     fun `isCwfLocalFilePathAllowed rejects blank uri and paths outside roots`() {
-        val root =
-            Paths.get(
-                System.getProperty("java.io.tmpdir"),
-                "cwf-guard-test",
-            ).toAbsolutePath().normalize().toString()
+        val root = createCwfGuardRoot()
         val roots = listOf(root)
 
         val outsideRoot =
-            Paths.get(
-                root,
-            ).resolveSibling("cwf-guard-outside").resolve("secret.txt").toAbsolutePath().normalize().toString()
+            Paths.get(root).resolveSibling("cwf-guard-outside").resolve("secret.txt").toAbsolutePath().normalize().toString()
 
         assertFalse(isCwfLocalFilePathAllowed("", roots))
         assertFalse(isCwfLocalFilePathAllowed("file:///etc/passwd", roots))
         assertFalse(isCwfLocalFilePathAllowed(outsideRoot, roots))
         assertFalse(isCwfLocalFilePathAllowed("../../../cwf-guard-outside/secret.txt", roots))
 
-        val inside = Paths.get(root, "src", "Main.kt")
-        File(inside.parent.toString()).mkdirs()
-        inside.toFile().writeText("")
-        assertTrue(isCwfLocalFilePathAllowed(inside.toString(), roots))
+        writeFileUnderRoot(root, "src/Main.kt")
+        assertTrue(isCwfLocalFilePathAllowed(Paths.get(root, "src/Main.kt").toString(), roots))
         assertTrue(isCwfLocalFilePathAllowed("src/Main.kt", roots))
         assertFalse(isCwfLocalFilePathAllowed("<<<", roots))
+    }
+
+    @Test
+    fun `isCwfLocalFilePathAllowed rejects blank invalid or unresolvable roots`() {
+        val root = createCwfGuardRoot()
+        writeFileUnderRoot(root, "src/Main.kt")
+
+        assertFalse(isCwfLocalFilePathAllowed("src/Main.kt", listOf("")))
+        assertFalse(isCwfLocalFilePathAllowed("src/Main.kt", listOf("   ")))
+        assertFalse(isCwfLocalFilePathAllowed("src/Main.kt", listOf("<<<")))
+        assertTrue(isCwfLocalFilePathAllowed("src/Main.kt", listOf(root, "<<<")))
+        assertFalse(isCwfLocalFilePathAllowed("src/missing.kt", listOf(root)))
+        assertFalse(isCwfLocalFilePathAllowed("a\u0000b.kt", listOf(root)))
+    }
+
+    @Test
+    fun `isRealPathUnderAllowedRoot returns false when root cannot be parsed`() {
+        val root = createCwfGuardRoot()
+        val candidate = Paths.get(writeFileUnderRoot(root, "f.kt"))
+        val invalidRoot = invalidRootForPathsGet()
+        try {
+            Paths.get(invalidRoot)
+            assumeTrue("Paths.get accepted invalid root on this OS", false)
+        } catch (_: InvalidPathException) {
+            assertFalse(isRealPathUnderAllowedRoot(candidate, invalidRoot))
+        }
+    }
+
+    @Test
+    fun `isCwfLocalFilePathAllowed allows absolute path under root`() {
+        val root = createCwfGuardRoot()
+        val absolute = writeFileUnderRoot(root, "Abs.kt")
+        assertTrue(isCwfLocalFilePathAllowed(Paths.get(absolute).toAbsolutePath().toString(), listOf(root)))
+        val invalidRoot = invalidRootForPathsGet()
+        try {
+            Paths.get(invalidRoot)
+            assumeTrue("Paths.get accepted invalid root on this OS", false)
+        } catch (_: InvalidPathException) {
+            assertFalse(isCwfLocalFilePathAllowed(Paths.get(absolute).toAbsolutePath().toString(), listOf(invalidRoot)))
+        }
+    }
+
+    @Test
+    fun `resolveRealPathString returns null when path is missing or access is denied`() {
+        val missing = Paths.get(System.getProperty("java.io.tmpdir"), "cwf-missing-${System.nanoTime()}")
+        assertNull(resolveRealPathString(missing))
+
+        val path = mockk<Path>()
+        every { path.toRealPath() } throws SecurityException("denied")
+        assertNull(resolveRealPathString(path))
     }
 
     @Test
@@ -155,6 +202,29 @@ class CwfActionLogicTest {
         assertEquals(TelemetryEvents.ACE_DIFF_SHOWN, telemetryForShowDiff(true, null, false)?.eventName)
         assertNull(telemetryForShowDiff(false, null, false))
     }
+
+    private fun createCwfGuardRoot(): String {
+        val root = Paths.get(System.getProperty("java.io.tmpdir"), "cwf-guard-test-${System.nanoTime()}")
+        root.toFile().mkdirs()
+        return root.toAbsolutePath().normalize().toString()
+    }
+
+    private fun writeFileUnderRoot(
+        root: String,
+        relative: String,
+    ): String {
+        val path = Paths.get(root, relative)
+        path.parent?.toFile()?.mkdirs()
+        path.toFile().writeText("")
+        return path.toString()
+    }
+
+    private fun invalidRootForPathsGet(): String =
+        if (System.getProperty("os.name").lowercase().contains("win")) {
+            "C:\\temp\\bad<file>"
+        } else {
+            "/tmp/bad<file>"
+        }
 
     private fun buildAceData(
         fileData: FileMetaType = FileMetaType(fn = Fn("f", RangeCamelCase(7, 1, 3, 1)), fileName = "/a.kt"),

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
@@ -13,9 +13,13 @@ import com.codescene.jetbrains.core.models.view.RecommendedAction
 import com.codescene.jetbrains.core.models.view.RefactorResponse
 import com.codescene.jetbrains.core.models.view.RefactoringProperties
 import com.codescene.jetbrains.core.util.TelemetryEvents
+import java.io.File
+import java.nio.file.Paths
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CwfActionLogicTest {
@@ -93,6 +97,31 @@ class CwfActionLogicTest {
     fun `resolveCopyAction uses client trace when no result data`() {
         val action = resolveCopyAction(null, codeFromPayload = "code", clientTraceId = "client-t")
         assertEquals(CopyAction("code", "client-t"), action)
+    }
+
+    @Test
+    fun `isCwfLocalFilePathAllowed rejects blank uri and paths outside roots`() {
+        val root =
+            Paths.get(
+                System.getProperty("java.io.tmpdir"),
+                "cwf-guard-test",
+            ).toAbsolutePath().normalize().toString()
+        val roots = listOf(root)
+
+        val outsideRoot =
+            Paths.get(
+                root,
+            ).resolveSibling("cwf-guard-outside").resolve("secret.txt").toAbsolutePath().normalize().toString()
+
+        assertFalse(isCwfLocalFilePathAllowed("", roots))
+        assertFalse(isCwfLocalFilePathAllowed("file:///etc/passwd", roots))
+        assertFalse(isCwfLocalFilePathAllowed(outsideRoot, roots))
+        assertFalse(isCwfLocalFilePathAllowed("../../../cwf-guard-outside/secret.txt", roots))
+
+        val inside = Paths.get(root, "src", "Main.kt").toString()
+        File(Paths.get(root, "src").toString()).mkdirs()
+        assertTrue(isCwfLocalFilePathAllowed(inside, roots))
+        assertTrue(isCwfLocalFilePathAllowed("src/Main.kt", roots))
     }
 
     @Test

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
@@ -118,10 +118,12 @@ class CwfActionLogicTest {
         assertFalse(isCwfLocalFilePathAllowed(outsideRoot, roots))
         assertFalse(isCwfLocalFilePathAllowed("../../../cwf-guard-outside/secret.txt", roots))
 
-        val inside = Paths.get(root, "src", "Main.kt").toString()
-        File(Paths.get(root, "src").toString()).mkdirs()
-        assertTrue(isCwfLocalFilePathAllowed(inside, roots))
+        val inside = Paths.get(root, "src", "Main.kt")
+        File(inside.parent.toString()).mkdirs()
+        inside.toFile().writeText("")
+        assertTrue(isCwfLocalFilePathAllowed(inside.toString(), roots))
         assertTrue(isCwfLocalFilePathAllowed("src/Main.kt", roots))
+        assertFalse(isCwfLocalFilePathAllowed("<<<", roots))
     }
 
     @Test

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
@@ -231,9 +231,9 @@ class CwfActionLogicTest {
 
     private fun invalidRootForPathsGet(): String =
         if (System.getProperty("os.name").lowercase().contains("win")) {
-            "C:\\temp\\bad<file>"
+            "C:\\temp\\bad\u0000file"
         } else {
-            "/tmp/bad<file>"
+            "/tmp/bad\u0000file"
         }
 
     private fun buildAceData(

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/AceCwfHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/AceCwfHandler.kt
@@ -36,6 +36,10 @@ class AceCwfHandler(private val project: Project) {
         source: AceEntryPoint,
         fnToRefactor: FnToRefactor? = null,
     ) {
+        if (!isCwfLocalFilePathAllowedForProject(project, fileData.fileName)) {
+            Log.warn("Rejected CWF refactoring for path outside project roots", "AceCwfHandler")
+            return
+        }
         if (fnToRefactor != null) {
             ApplicationManager.getApplication().executeOnPooledThread {
                 val token = appServices.settingsProvider.getAceAuthToken()

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/CwfLocalFilePathGuard.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/CwfLocalFilePathGuard.kt
@@ -1,25 +1,64 @@
 package com.codescene.jetbrains.platform.util
 
 import com.codescene.jetbrains.core.handler.isCwfLocalFilePathAllowed
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import git4idea.repo.GitRepository
+import git4idea.repo.GitRepositoryChangeListener
 import git4idea.repo.GitRepositoryManager
 import java.nio.file.Paths
 
-fun cwfAllowedLocalFileRoots(project: Project): Set<String> {
-    val roots = linkedSetOf<String>()
-    project.basePath?.let { base ->
-        roots.add(Paths.get(base).toAbsolutePath().normalize().toString())
+@Service(Service.Level.PROJECT)
+class CwfLocalFilePathGuardService(
+    private val project: Project,
+) : Disposable {
+    @Volatile
+    private var cachedRoots: Set<String>? = null
+
+    private val connection = project.messageBus.connect(this)
+
+    init {
+        connection.subscribe(
+            GitRepository.GIT_REPO_CHANGE,
+            GitRepositoryChangeListener { invalidate() },
+        )
     }
-    runReadAction {
-        GitRepositoryManager.getInstance(project).repositories.forEach { repository ->
-            roots.add(Paths.get(repository.root.path).toAbsolutePath().normalize().toString())
+
+    fun invalidate() {
+        cachedRoots = null
+    }
+
+    fun allowedRoots(): Set<String> = cachedRoots ?: computeAllowedRoots().also { cachedRoots = it }
+
+    fun isAllowed(filePath: String): Boolean = isCwfLocalFilePathAllowed(filePath, allowedRoots())
+
+    private fun computeAllowedRoots(): Set<String> {
+        val roots = linkedSetOf<String>()
+        project.basePath?.let { base ->
+            roots.add(Paths.get(base).toAbsolutePath().normalize().toString())
         }
+        runReadAction {
+            GitRepositoryManager.getInstance(project).repositories.forEach { repository ->
+                roots.add(Paths.get(repository.root.path).toAbsolutePath().normalize().toString())
+            }
+        }
+        return roots
     }
-    return roots
+
+    override fun dispose() {
+        connection.disconnect()
+        cachedRoots = null
+    }
+
+    companion object {
+        fun getInstance(project: Project): CwfLocalFilePathGuardService = project.service()
+    }
 }
 
 fun isCwfLocalFilePathAllowedForProject(
     project: Project,
     filePath: String,
-): Boolean = isCwfLocalFilePathAllowed(filePath, cwfAllowedLocalFileRoots(project))
+): Boolean = CwfLocalFilePathGuardService.getInstance(project).isAllowed(filePath)

--- a/src/main/kotlin/com/codescene/jetbrains/platform/util/CwfLocalFilePathGuard.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/util/CwfLocalFilePathGuard.kt
@@ -1,0 +1,25 @@
+package com.codescene.jetbrains.platform.util
+
+import com.codescene.jetbrains.core.handler.isCwfLocalFilePathAllowed
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.project.Project
+import git4idea.repo.GitRepositoryManager
+import java.nio.file.Paths
+
+fun cwfAllowedLocalFileRoots(project: Project): Set<String> {
+    val roots = linkedSetOf<String>()
+    project.basePath?.let { base ->
+        roots.add(Paths.get(base).toAbsolutePath().normalize().toString())
+    }
+    runReadAction {
+        GitRepositoryManager.getInstance(project).repositories.forEach { repository ->
+            roots.add(Paths.get(repository.root.path).toAbsolutePath().normalize().toString())
+        }
+    }
+    return roots
+}
+
+fun isCwfLocalFilePathAllowedForProject(
+    project: Project,
+    filePath: String,
+): Boolean = isCwfLocalFilePathAllowed(filePath, cwfAllowedLocalFileRoots(project))

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/handler/CwfAceActionHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/handler/CwfAceActionHandler.kt
@@ -21,6 +21,7 @@ import com.codescene.jetbrains.platform.util.AceEntryOrchestrator
 import com.codescene.jetbrains.platform.util.Log
 import com.codescene.jetbrains.platform.util.ReplaceCodeSnippetArgs
 import com.codescene.jetbrains.platform.util.closeWindow
+import com.codescene.jetbrains.platform.util.isCwfLocalFilePathAllowedForProject
 import com.codescene.jetbrains.platform.util.replaceCodeSnippet
 import com.codescene.jetbrains.platform.util.showAceDiff
 import com.codescene.jetbrains.platform.util.showInfoNotification
@@ -73,6 +74,10 @@ class CwfAceActionHandler(
 
     fun handleRequestAndPresentRefactoring(request: RequestAndPresentRefactoring) {
         val filePath = request.filePath ?: request.fileName
+        if (!isCwfLocalFilePathAllowedForProject(project, filePath)) {
+            Log.warn("Rejected CWF refactoring request for path outside project roots", serviceName)
+            return
+        }
         val fnToRefactor = resolveRequestedFunctionToRefactor(request, filePath)
         orchestrator.handleRefactoringFromCwf(
             FileMetaType(
@@ -85,6 +90,9 @@ class CwfAceActionHandler(
     }
 
     private fun contentForAceCacheLookup(filePath: String): String? {
+        if (!isCwfLocalFilePathAllowedForProject(project, filePath)) {
+            return null
+        }
         val virtualFile = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return null
         val fromDocument =
             runReadAction<String?> {
@@ -147,6 +155,10 @@ class CwfAceActionHandler(
     ): Pair<FileMetaType, FnToRefactor?>? {
         payload ?: return null
         val filePath = payload.filePath ?: payload.fileName ?: return null
+        if (!isCwfLocalFilePathAllowedForProject(project, filePath)) {
+            Log.warn("Rejected CWF acknowledged refactor for path outside project roots", serviceName)
+            return null
+        }
         val baseFn = payload.fn ?: return null
         val fnWithRange =
             when {

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/handler/CwfMessageHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/handler/CwfMessageHandler.kt
@@ -20,6 +20,7 @@ import com.codescene.jetbrains.platform.di.CodeSceneApplicationServiceProvider
 import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
 import com.codescene.jetbrains.platform.util.AceEntryOrchestrator
 import com.codescene.jetbrains.platform.util.Log
+import com.codescene.jetbrains.platform.util.isCwfLocalFilePathAllowedForProject
 import com.codescene.jetbrains.platform.webview.CwfWebviewLifecycle
 import com.codescene.jetbrains.platform.webview.WebViewInitializer
 import com.codescene.jetbrains.platform.webview.util.aceAcknowledgeRefreshMessage
@@ -191,6 +192,11 @@ class CwfMessageHandler(
     }
 
     override fun handleOpenDocs(docsForFunction: OpenDocsForFunction) {
+        val filePath = docsForFunction.fileName
+        if (!isCwfLocalFilePathAllowedForProject(project, filePath)) {
+            Log.warn("Rejected CWF open docs for path outside project roots", serviceName)
+            return
+        }
         val docsData = toDocsData(docsForFunction)
         val fnToRefactor =
             resolveFnToRefactorForDocumentation(
@@ -240,6 +246,10 @@ class CwfMessageHandler(
 
     private fun handleOpenFile(message: GotoFunctionLocation) {
         val filePath = message.fileName ?: return
+        if (!isCwfLocalFilePathAllowedForProject(project, filePath)) {
+            Log.warn("Rejected CWF goto location for path outside project roots", serviceName)
+            return
+        }
         val line = message.fn?.range?.startLine ?: 0
         val column = message.fn?.range?.startColumn ?: 0
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/OpenDocs.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/OpenDocs.kt
@@ -19,6 +19,7 @@ import com.codescene.jetbrains.platform.fileeditor.documentation.CWF_DOCS_FN_TO_
 import com.codescene.jetbrains.platform.util.FileUtils
 import com.codescene.jetbrains.platform.util.Log
 import com.codescene.jetbrains.platform.util.getSelectedTextEditor
+import com.codescene.jetbrains.platform.util.isCwfLocalFilePathAllowedForProject
 import com.codescene.jetbrains.platform.webview.WebViewInitializer
 import com.codescene.jetbrains.platform.webview.handler.CwfMessageHandler
 import com.intellij.openapi.application.runReadAction
@@ -83,6 +84,9 @@ internal fun resolveFnToRefactorForDocumentation(
 ): FnToRefactor? {
     val filePath = fileData.fileName
     if (filePath.isBlank()) return null
+    if (!isCwfLocalFilePathAllowedForProject(project, filePath)) {
+        return null
+    }
     val services = CodeSceneProjectServiceProvider.getInstance(project)
     val code =
         preferredDocumentText


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/9015696197/CS-11202

## Problem
The CWF JavaScript bridge handled `goto`, documentation, and refactoring messages with raw `fileName` / `filePath` values and opened or read any local path via `LocalFileSystem`, allowing a compromised webview to access files outside the project.

## Fix
- Add `isCwfLocalFilePathAllowed` in core to resolve paths against allowed roots and reject `file:` URIs.
- Add `CwfLocalFilePathGuard` using project base path and Git repository roots.
- Enforce the guard on CWF handlers: goto location, open docs, refactoring requests, acknowledged payloads, and ACE file reads.

## Test plan
- [x] From Code Health details in CWF, click through to a function in a project file (should still navigate).
- [x] `gradlew` ktlint + `core:test` + `test` + `buildPlugin` passed in worktree `CS-11202`
- [x] CodeScene MCP change-set review (run before merge if not already done in CI)