### PR TITLE
CS-11208: Sanitize open-link telemetry URLs

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
@@ -146,8 +146,6 @@ private fun sanitizedTelemetryUrl(url: String): String {
         URI(uri.scheme, null, uri.host, -1, uri.path, null, null).toString()
     } catch (_: URISyntaxException) {
         ""
-    } catch (_: IllegalArgumentException) {
-        ""
     }
 }
 

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
@@ -6,6 +6,8 @@ import com.codescene.jetbrains.core.models.view.AceData
 import com.codescene.jetbrains.core.models.view.DocsData
 import com.codescene.jetbrains.core.util.Constants.ALLOWED_DOMAINS
 import com.codescene.jetbrains.core.util.TelemetryEvents
+import java.net.URI
+import java.net.URISyntaxException
 
 data class ApplyAction(
     val filePath: String,
@@ -135,6 +137,18 @@ fun telemetryForShowDiff(
     }
 
 fun telemetryForOpenUrl(url: String): CwfTelemetryEvent =
-    CwfTelemetryEvent(TelemetryEvents.OPEN_LINK, mutableMapOf(Pair("url", url)))
+    CwfTelemetryEvent(TelemetryEvents.OPEN_LINK, mutableMapOf(Pair("url", sanitizedTelemetryUrl(url))))
+
+private fun sanitizedTelemetryUrl(url: String): String {
+    return try {
+        val uri = URI(url)
+        if (uri.scheme.isNullOrBlank() || uri.host.isNullOrBlank()) return ""
+        URI(uri.scheme, null, uri.host, -1, uri.path, null, null).toString()
+    } catch (_: URISyntaxException) {
+        ""
+    } catch (_: IllegalArgumentException) {
+        ""
+    }
+}
 
 fun telemetryForOpenSettings(): CwfTelemetryEvent = CwfTelemetryEvent(TelemetryEvents.OPEN_SETTINGS)

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
@@ -125,6 +125,26 @@ class CwfActionLogicTest {
         assertNull(telemetryForShowDiff(false, null, false))
     }
 
+    @Test
+    fun `telemetryForOpenUrl strips sensitive url parts`() {
+        assertEquals(
+            mapOf("url" to "https://codescene.io/docs/page"),
+            telemetryForOpenUrl("https://codescene.io/docs/page?token=secret#section").data,
+        )
+        assertEquals(
+            mapOf("url" to "https://codescene.io/docs"),
+            telemetryForOpenUrl("https://user:password@codescene.io/docs").data,
+        )
+        assertEquals(
+            mapOf("url" to "https://codescene.io"),
+            telemetryForOpenUrl("https://codescene.io").data,
+        )
+        assertEquals(
+            mapOf("url" to ""),
+            telemetryForOpenUrl("not a url ?token=secret").data,
+        )
+    }
+
     private fun buildAceData(
         fileData: FileMetaType = FileMetaType(fn = Fn("f", RangeCamelCase(7, 1, 3, 1)), fileName = "/a.kt"),
         code: String,

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
@@ -143,6 +143,10 @@ class CwfActionLogicTest {
             mapOf("url" to ""),
             telemetryForOpenUrl("not a url ?token=secret").data,
         )
+        assertEquals(
+            mapOf("url" to ""),
+            telemetryForOpenUrl("https://[::1").data,
+        )
     }
 
     private fun buildAceData(

--- a/docs/agentic-dev-flow/CS-11208/plan.md
+++ b/docs/agentic-dev-flow/CS-11208/plan.md
@@ -1,0 +1,45 @@
+# CS-11208: Telemetry events ship full clicked URLs
+
+**Goal:** Prevent open-link telemetry from sending clicked URLs with query strings, fragments, userinfo, or other sensitive URL components.
+
+**Approach:** Keep browser behavior unchanged and sanitize only the telemetry payload in core business logic. Build the open-link telemetry event from a redacted URL representation that preserves `scheme://host/path` for valid URLs and never falls back to the original string for malformed input.
+
+## Context
+
+The ClickUp ticket identifies a privacy issue in `core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt`: `telemetryForOpenUrl(url: String)` currently sends the full URL in telemetry. Full clicked URLs can include query strings, fragments, userinfo, tokens, or per-user identifiers. The platform handler should still open the original clicked URL, but telemetry sent through `TelemetryService` and `ExtensionAPI.sendTelemetry` must not include sensitive URL components.
+
+## Acceptance Criteria
+
+- Open-link telemetry does not include URL query strings.
+- Open-link telemetry does not include URL fragments.
+- Open-link telemetry does not include URL userinfo such as embedded username/password data.
+- Valid URL telemetry keeps only the scheme, host, and path.
+- Malformed URL input does not cause telemetry to contain the original unsanitized URL.
+- Existing URL-opening behavior remains unchanged.
+
+---
+
+### Task 1: Sanitize Open-Link Telemetry URLs
+
+**Files:**
+
+- Modify: `core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt`
+- Test: `core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt`
+
+**Intent:** Centralize open-link telemetry redaction in the existing core telemetry helper so every caller gets safe telemetry data without changing platform URL-opening behavior. The platform handler continues to pass and open the original URL, while `telemetryForOpenUrl` stores only a sanitized value in the event data.
+
+**Key signatures/shapes:**
+
+- `fun telemetryForOpenUrl(url: String): CwfTelemetryEvent` returns `TelemetryEvents.OPEN_LINK` with `data["url"]` set to the sanitized URL value.
+- `private fun sanitizedTelemetryUrl(url: String): String` parses the URL and returns only `scheme://host/path` for valid URLs.
+- For URLs that cannot be parsed into a scheme and host, `sanitizedTelemetryUrl` returns an empty string, not the original input.
+
+**Test strategy:**
+
+- Scenario: `telemetryForOpenUrl("https://codescene.io/docs/page?token=secret#section")` produces data `mapOf("url" to "https://codescene.io/docs/page")`.
+- Scenario: `telemetryForOpenUrl("https://user:password@codescene.io/docs")` produces data `mapOf("url" to "https://codescene.io/docs")`.
+- Scenario: `telemetryForOpenUrl("https://codescene.io")` keeps the origin as `"https://codescene.io"`.
+- Edge case: `telemetryForOpenUrl("not a url ?token=secret")` produces data `mapOf("url" to "")`.
+- Regression: existing helper event-name assertions still pass for `OPEN_LINK` and other telemetry helpers.
+
+**Commit:** `CS-11208: sanitize open-link telemetry URLs`


### PR DESCRIPTION
## Summary

Sanitizes open-link telemetry so clicked URLs no longer send query strings, fragments, userinfo, or malformed raw input. Browser behavior remains unchanged: the original URL is still opened, while telemetry records only a safe `scheme://host/path` representation for valid URLs.

## Ticket

https://app.clickup.com/t/86c9rpr5c

## Changes

- Updated `telemetryForOpenUrl` in core logic to sanitize URL telemetry payloads.
- Added a private sanitizer that keeps only scheme, host, and path for valid URLs.
- Ensured malformed URL input produces an empty telemetry URL instead of the original string.
- Added unit coverage for query/fragment removal, userinfo removal, origin-only URLs, and malformed input.

## Testing

- `./gradlew :core:test --tests com.codescene.jetbrains.core.handler.CwfActionLogicTest`
- `GH_USERNAME="$(gh api user --jq .login)" make iter`

## Acceptance Criteria

- [x] Open-link telemetry does not include URL query strings.
- [x] Open-link telemetry does not include URL fragments.
- [x] Open-link telemetry does not include URL userinfo such as embedded username/password data.
- [x] Valid URL telemetry keeps only the scheme, host, and path.
- [x] Malformed URL input does not cause telemetry to contain the original unsanitized URL.
- [x] Existing URL-opening behavior remains unchanged.