### PR TITLE
CS-11206: Safely embed JSON and CSS in webview scripts

### DIFF
--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/WebViewInitializer.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/WebViewInitializer.kt
@@ -8,6 +8,7 @@ import com.codescene.jetbrains.core.models.view.AceAcknowledgeData
 import com.codescene.jetbrains.core.models.view.AceData
 import com.codescene.jetbrains.core.models.view.DocsData
 import com.codescene.jetbrains.core.models.view.HomeData
+import com.codescene.jetbrains.platform.webview.util.JsEmbedEscapes
 import com.codescene.jetbrains.platform.webview.util.StyleHelper
 import com.intellij.ide.ui.LafManager
 import com.intellij.ide.ui.LafManagerListener
@@ -70,6 +71,10 @@ class WebViewInitializer(
 
         val css = getFileContent("cs-cwf/index.css")
         val js = getFileContent("cs-cwf/index.js")
+        val ideContextJson =
+            JsEmbedEscapes.escapeJsonForHtmlScript(getInitialContext(view, initialData))
+        val themeCssLiteral =
+            JsEmbedEscapes.toJsStringLiteral(StyleHelper.getInstance().generateCssVariablesFromTheme())
 
         return """
             <!DOCTYPE html>
@@ -87,14 +92,14 @@ class WebViewInitializer(
                 ">
                 <title>JetBrains React Webview</title>
                 <style>$css</style>
+                <script type="application/json" id="ide-context">$ideContextJson</script>
                 <script type="module">
                   ${getLinkClickHandler()}
                   function setContext() {
-                    window.ideContext = ${getInitialContext(view, initialData)}
-                    const css = `${StyleHelper.getInstance().generateCssVariablesFromTheme()}`;
+                    window.ideContext = JSON.parse(document.getElementById('ide-context').textContent);
                     const style = document.createElement('style');
                     style.id = '{STYLE_ELEMENT_ID}';
-                    style.textContent = css;
+                    style.textContent = $themeCssLiteral;
                     document.head.appendChild(style);
                   }
                   setContext();
@@ -122,6 +127,7 @@ class WebViewInitializer(
      */
     override fun lookAndFeelChanged(p0: LafManager) {
         val css = StyleHelper.getInstance().generateCssVariablesFromTheme()
+        val cssLiteral = JsEmbedEscapes.toJsStringLiteral(css)
 
         val js =
             """
@@ -132,7 +138,7 @@ class WebViewInitializer(
                     style.id = '{STYLE_ELEMENT_ID}';
                     document.head.appendChild(style);
                 }
-                style.textContent = `$css`;
+                style.textContent = $cssLiteral;
             })();
             """.trimIndent()
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/handler/CwfMessageHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/handler/CwfMessageHandler.kt
@@ -22,6 +22,7 @@ import com.codescene.jetbrains.platform.util.AceEntryOrchestrator
 import com.codescene.jetbrains.platform.util.Log
 import com.codescene.jetbrains.platform.webview.CwfWebviewLifecycle
 import com.codescene.jetbrains.platform.webview.WebViewInitializer
+import com.codescene.jetbrains.platform.webview.util.JsEmbedEscapes
 import com.codescene.jetbrains.platform.webview.util.aceAcknowledgeRefreshMessage
 import com.codescene.jetbrains.platform.webview.util.docsRefreshMessage
 import com.codescene.jetbrains.platform.webview.util.openDocs
@@ -121,8 +122,9 @@ class CwfMessageHandler(
             Log.warn("postMessageDirect browser null view=${view.value}", serviceName)
             return
         }
+        val messageLiteral = JsEmbedEscapes.toJsStringLiteral(message)
         registeredBrowser.cefBrowser.executeJavaScript(
-            "window.postMessage($message);",
+            "window.postMessage(JSON.parse($messageLiteral));",
             null,
             0,
         )

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/JsEmbedEscapes.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/JsEmbedEscapes.kt
@@ -1,0 +1,15 @@
+package com.codescene.jetbrains.platform.webview.util
+
+import kotlinx.serialization.json.Json
+
+object JsEmbedEscapes {
+    private val json = Json
+
+    fun toJsStringLiteral(value: String): String = json.encodeToString(value)
+
+    fun escapeJsonForHtmlScript(json: String): String =
+        json
+            .replace("</", "<\\/")
+            .replace("\u2028", "\\u2028")
+            .replace("\u2029", "\\u2029")
+}

--- a/src/test/kotlin/com/codescene/jetbrains/platform/webview/util/JsEmbedEscapesTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/webview/util/JsEmbedEscapesTest.kt
@@ -1,0 +1,26 @@
+package com.codescene.jetbrains.platform.webview.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class JsEmbedEscapesTest {
+    @Test
+    fun `toJsStringLiteral quotes and escapes backticks`() {
+        val literal = JsEmbedEscapes.toJsStringLiteral("a`b\${c}")
+        assertEquals("\"a`b\${c}\"", literal)
+    }
+
+    @Test
+    fun `escapeJsonForHtmlScript breaks script closing sequence`() {
+        val escaped = JsEmbedEscapes.escapeJsonForHtmlScript("{\"x\":\"</script>\"}")
+        assertFalse(escaped.contains("</script>"))
+        assertEquals("{\"x\":\"<\\/script>\"}", escaped)
+    }
+
+    @Test
+    fun `escapeJsonForHtmlScript escapes line separators`() {
+        val input = "a\u2028b\u2029c"
+        assertEquals("a\\u2028b\\u2029c", JsEmbedEscapes.escapeJsonForHtmlScript(input))
+    }
+}


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpqp0 (CS-11206)

## Problem
IDE context JSON, theme CSS, and CWF postMessage payloads were concatenated into executable JS/HTML without escaping. Hostile content could break out via </script>, backticks, or unquoted postMessage arguments (CWE-79 / CWE-94).

## Fix
- Load initial IDE context from a non-executing application/json script block; parse with JSON.parse.
- Embed theme CSS and outbound messages via JSON-encoded string literals (JsEmbedEscapes).
- Escape </script> and U+2028/U+2029 in HTML JSON payloads.

## Test plan
- [ ] Open HOME/ACE/DOCS webviews; confirm context loads and theme updates on LAF change
- [x] gradlew ktlintCheck, buildPlugin, test passed; CodeScene MCP analyze_change_set + per-file reviews passed

Made with [Cursor](https://cursor.com)