### PR TITLE
CS-11211: fail fast for missing Gradle GitHub tokens

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -17,6 +17,12 @@ val codeSceneExtensionAPIVersion = rootProject.providers.gradleProperty("codeSce
 val codeSceneRepository = rootProject.providers.gradleProperty("codeSceneRepository").get()
 val slf4jNopVersion = rootProject.providers.gradleProperty("slf4jNopVersion").get()
 
+fun requiredEnv(name: String): String =
+    System.getenv(name)
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?: throw GradleException("Missing required environment variable: $name")
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -24,7 +30,7 @@ repositories {
         url = uri(codeSceneRepository)
         credentials {
             username = System.getenv("GH_USERNAME")
-            password = System.getenv("GH_PACKAGE_TOKEN")
+            password = requiredEnv("GH_PACKAGE_TOKEN")
         }
     }
 }

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -23,6 +23,21 @@ fun requiredEnv(name: String): String =
         ?.takeIf { it.isNotEmpty() }
         ?: throw GradleException("Missing required environment variable: $name")
 
+fun optionalEnv(name: String): String? =
+    System.getenv(name)
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+
+fun requireGithubPackageTokenForDependencyResolution() {
+    configurations.configureEach {
+        incoming.beforeResolve {
+            requiredEnv("GH_PACKAGE_TOKEN")
+        }
+    }
+}
+
+requireGithubPackageTokenForDependencyResolution()
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -30,7 +45,7 @@ repositories {
         url = uri(codeSceneRepository)
         credentials {
             username = System.getenv("GH_USERNAME")
-            password = requiredEnv("GH_PACKAGE_TOKEN")
+            password = optionalEnv("GH_PACKAGE_TOKEN")
         }
     }
 }

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -28,15 +28,16 @@ fun optionalEnv(name: String): String? =
         ?.trim()
         ?.takeIf { it.isNotEmpty() }
 
-fun requireGithubPackageTokenForDependencyResolution() {
+fun requireGithubPackageCredentialsForDependencyResolution() {
     configurations.configureEach {
         incoming.beforeResolve {
+            requiredEnv("GH_USERNAME")
             requiredEnv("GH_PACKAGE_TOKEN")
         }
     }
 }
 
-requireGithubPackageTokenForDependencyResolution()
+requireGithubPackageCredentialsForDependencyResolution()
 
 repositories {
     mavenLocal()
@@ -44,7 +45,7 @@ repositories {
     maven {
         url = uri(codeSceneRepository)
         credentials {
-            username = System.getenv("GH_USERNAME")
+            username = optionalEnv("GH_USERNAME")
             password = optionalEnv("GH_PACKAGE_TOKEN")
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,12 @@ val kotlinxSerializationVersion = providers.gradleProperty("kotlinxSerialization
 val slf4jNopVersion = providers.gradleProperty("slf4jNopVersion").get()
 val kotlinxCoroutinesVersion = providers.gradleProperty("kotlinxCoroutinesVersion").get()
 
+fun requiredEnv(name: String): String =
+    System.getenv(name)
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?: throw GradleException("Missing required environment variable: $name")
+
 // Set the JVM language level used to build the project.
 kotlin {
     jvmToolchain(17)
@@ -44,7 +50,7 @@ repositories {
         url = uri(codeSceneRepository)
         credentials {
             username = System.getenv("GH_USERNAME")
-            password = System.getenv("GH_PACKAGE_TOKEN")
+            password = requiredEnv("GH_PACKAGE_TOKEN")
         }
     }
 
@@ -301,12 +307,13 @@ tasks.register("fetchCwf") {
     val assetType = "cs-cwf"
     val user = "empear-analytics"
     val repo = "cs-webview"
-    val token =
+    val tokenEnvName =
         if (System.getenv("CI") == "true") {
-            System.getenv("CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN")
+            "CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN"
         } else {
-            System.getenv("GH_PACKAGE_TOKEN")
+            "GH_PACKAGE_TOKEN"
         }
+    val token = requiredEnv(tokenEnvName)
 
     doLast {
         val apiUrl = "https://api.github.com/repos/$user/$repo/releases"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,21 +49,11 @@ fun requireGithubPackageTokenForDependencyResolution() {
     }
 }
 
-fun isTaskRequested(name: String): Boolean =
-    gradle.startParameter.taskNames.any { taskName -> taskName == name || taskName.endsWith(":$name") }
-
 val cwfTokenEnvName =
     if (System.getenv("CI") == "true") {
         "CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN"
     } else {
         "GH_PACKAGE_TOKEN"
-    }
-
-val prevalidatedCwfToken =
-    if (isTaskRequested("fetchCwf") || isTaskRequested("buildPlugin")) {
-        requiredEnv(cwfTokenEnvName)
-    } else {
-        null
     }
 
 requireGithubPackageTokenForDependencyResolution()
@@ -339,9 +329,9 @@ tasks.register("fetchCwf") {
     val assetType = "cs-cwf"
     val user = "empear-analytics"
     val repo = "cs-webview"
-    val token = prevalidatedCwfToken ?: requiredEnv(cwfTokenEnvName)
 
     doLast {
+        val token = requiredEnv(cwfTokenEnvName)
         val apiUrl = "https://api.github.com/repos/$user/$repo/releases"
 
         val releasesJson =

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,38 @@ fun requiredEnv(name: String): String =
         ?.takeIf { it.isNotEmpty() }
         ?: throw GradleException("Missing required environment variable: $name")
 
+fun optionalEnv(name: String): String? =
+    System.getenv(name)
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+
+fun requireGithubPackageTokenForDependencyResolution() {
+    configurations.configureEach {
+        incoming.beforeResolve {
+            requiredEnv("GH_PACKAGE_TOKEN")
+        }
+    }
+}
+
+fun isTaskRequested(name: String): Boolean =
+    gradle.startParameter.taskNames.any { taskName -> taskName == name || taskName.endsWith(":$name") }
+
+val cwfTokenEnvName =
+    if (System.getenv("CI") == "true") {
+        "CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN"
+    } else {
+        "GH_PACKAGE_TOKEN"
+    }
+
+val prevalidatedCwfToken =
+    if (isTaskRequested("fetchCwf") || isTaskRequested("buildPlugin")) {
+        requiredEnv(cwfTokenEnvName)
+    } else {
+        null
+    }
+
+requireGithubPackageTokenForDependencyResolution()
+
 // Set the JVM language level used to build the project.
 kotlin {
     jvmToolchain(17)
@@ -50,7 +82,7 @@ repositories {
         url = uri(codeSceneRepository)
         credentials {
             username = System.getenv("GH_USERNAME")
-            password = requiredEnv("GH_PACKAGE_TOKEN")
+            password = optionalEnv("GH_PACKAGE_TOKEN")
         }
     }
 
@@ -307,13 +339,7 @@ tasks.register("fetchCwf") {
     val assetType = "cs-cwf"
     val user = "empear-analytics"
     val repo = "cs-webview"
-    val tokenEnvName =
-        if (System.getenv("CI") == "true") {
-            "CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN"
-        } else {
-            "GH_PACKAGE_TOKEN"
-        }
-    val token = requiredEnv(tokenEnvName)
+    val token = prevalidatedCwfToken ?: requiredEnv(cwfTokenEnvName)
 
     doLast {
         val apiUrl = "https://api.github.com/repos/$user/$repo/releases"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,9 +41,10 @@ fun optionalEnv(name: String): String? =
         ?.trim()
         ?.takeIf { it.isNotEmpty() }
 
-fun requireGithubPackageTokenForDependencyResolution() {
+fun requireGithubPackageCredentialsForDependencyResolution() {
     configurations.configureEach {
         incoming.beforeResolve {
+            requiredEnv("GH_USERNAME")
             requiredEnv("GH_PACKAGE_TOKEN")
         }
     }
@@ -56,7 +57,7 @@ val cwfTokenEnvName =
         "GH_PACKAGE_TOKEN"
     }
 
-requireGithubPackageTokenForDependencyResolution()
+requireGithubPackageCredentialsForDependencyResolution()
 
 // Set the JVM language level used to build the project.
 kotlin {
@@ -71,7 +72,7 @@ repositories {
     maven {
         url = uri(codeSceneRepository)
         credentials {
-            username = System.getenv("GH_USERNAME")
+            username = optionalEnv("GH_USERNAME")
             password = optionalEnv("GH_PACKAGE_TOKEN")
         }
     }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,15 +30,16 @@ fun optionalEnv(name: String): String? =
         ?.trim()
         ?.takeIf { it.isNotEmpty() }
 
-fun requireGithubPackageTokenForDependencyResolution() {
+fun requireGithubPackageCredentialsForDependencyResolution() {
     configurations.configureEach {
         incoming.beforeResolve {
+            requiredEnv("GH_USERNAME")
             requiredEnv("GH_PACKAGE_TOKEN")
         }
     }
 }
 
-requireGithubPackageTokenForDependencyResolution()
+requireGithubPackageCredentialsForDependencyResolution()
 
 repositories {
     mavenLocal()
@@ -46,7 +47,7 @@ repositories {
     maven {
         url = uri(codeSceneRepository)
         credentials {
-            username = System.getenv("GH_USERNAME")
+            username = optionalEnv("GH_USERNAME")
             password = optionalEnv("GH_PACKAGE_TOKEN")
         }
     }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -25,6 +25,21 @@ fun requiredEnv(name: String): String =
         ?.takeIf { it.isNotEmpty() }
         ?: throw GradleException("Missing required environment variable: $name")
 
+fun optionalEnv(name: String): String? =
+    System.getenv(name)
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+
+fun requireGithubPackageTokenForDependencyResolution() {
+    configurations.configureEach {
+        incoming.beforeResolve {
+            requiredEnv("GH_PACKAGE_TOKEN")
+        }
+    }
+}
+
+requireGithubPackageTokenForDependencyResolution()
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -32,7 +47,7 @@ repositories {
         url = uri(codeSceneRepository)
         credentials {
             username = System.getenv("GH_USERNAME")
-            password = requiredEnv("GH_PACKAGE_TOKEN")
+            password = optionalEnv("GH_PACKAGE_TOKEN")
         }
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -19,6 +19,12 @@ val mockkVersion = rootProject.providers.gradleProperty("mockkVersion").get()
 val slf4jNopVersion = rootProject.providers.gradleProperty("slf4jNopVersion").get()
 val kotlinxCoroutinesVersion = rootProject.providers.gradleProperty("kotlinxCoroutinesVersion").get()
 
+fun requiredEnv(name: String): String =
+    System.getenv(name)
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?: throw GradleException("Missing required environment variable: $name")
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -26,7 +32,7 @@ repositories {
         url = uri(codeSceneRepository)
         credentials {
             username = System.getenv("GH_USERNAME")
-            password = System.getenv("GH_PACKAGE_TOKEN")
+            password = requiredEnv("GH_PACKAGE_TOKEN")
         }
     }
 }


### PR DESCRIPTION
## Summary

Fail fast with clear Gradle errors when required GitHub tokens are missing for CWF asset downloads or private CodeScene Maven dependency resolution. This prevents `fetchCwf` from sending `Authorization: token null` and replaces noisy Maven 401 failures with explicit missing-environment-variable diagnostics.

## Ticket

https://app.clickup.com/t/86c9rprc3

## Changes

- Added `requiredEnv` and `optionalEnv` helpers in Gradle Kotlin scripts to trim env vars and treat blanks as missing.
- Updated `fetchCwf` to resolve the CI/local token only during task execution before opening GitHub connections.
- Added dependency-resolution preflight checks for `GH_PACKAGE_TOKEN` in root, `core`, and `benchmarks` Gradle scripts.
- Kept unrelated Gradle operations like `./gradlew tasks` usable without CWF/package tokens.

## Testing

- `make iter`
- `env -u GH_PACKAGE_TOKEN -u CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN ./gradlew fetchCwf --no-daemon`
- `env -u GH_PACKAGE_TOKEN -u CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN CI=true ./gradlew fetchCwf --no-daemon`
- `env -u GH_PACKAGE_TOKEN ./gradlew dependencies --configuration runtimeClasspath --no-daemon`
- `env -u GH_PACKAGE_TOKEN ./gradlew :core:dependencies --configuration runtimeClasspath --no-daemon`
- `env -u GH_PACKAGE_TOKEN ./gradlew :benchmarks:dependencies --configuration jmh --no-daemon`
- `env -u GH_PACKAGE_TOKEN -u CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN ./gradlew tasks --quiet --no-daemon`

## Acceptance Criteria

- [x] `fetchCwf` must not send `Authorization: token null` or an empty token value.
- [x] Missing `CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN` in CI must fail fast with a clear `GradleException` naming the missing variable.
- [x] Missing `GH_PACKAGE_TOKEN` outside CI must fail fast with a clear `GradleException` naming the missing variable.
- [x] Private CodeScene Maven repository credentials must fail with clear diagnostics when `GH_PACKAGE_TOKEN` is missing or blank.
- [x] Token values must never be included in error messages or logs.