### PR TITLE
CS-11203: validate CWF URLs by parsed host

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogic.kt
@@ -4,8 +4,10 @@ import com.codescene.jetbrains.core.models.message.OpenDocsForFunction
 import com.codescene.jetbrains.core.models.shared.FileMetaType
 import com.codescene.jetbrains.core.models.view.AceData
 import com.codescene.jetbrains.core.models.view.DocsData
-import com.codescene.jetbrains.core.util.Constants.ALLOWED_DOMAINS
+import com.codescene.jetbrains.core.util.AllowedUrlRule
+import com.codescene.jetbrains.core.util.Constants.ALLOWED_URL_RULES
 import com.codescene.jetbrains.core.util.TelemetryEvents
+import java.net.URI
 
 data class ApplyAction(
     val filePath: String,
@@ -49,7 +51,25 @@ fun resolveCopyAction(
     return CopyAction(code = code, traceId = traceId)
 }
 
-fun isUrlAllowed(url: String): Boolean = url.isNotBlank() && ALLOWED_DOMAINS.any { url.startsWith(it) }
+fun isUrlAllowed(url: String): Boolean {
+    if (url.isBlank()) return false
+
+    val uri = runCatching { URI(url) }.getOrNull() ?: return false
+    val host = uri.host?.lowercase()?.takeIf { it.isNotBlank() } ?: return false
+
+    return uri.scheme == "https" &&
+        uri.userInfo == null &&
+        uri.port == -1 &&
+        !host.endsWith(".") &&
+        ALLOWED_URL_RULES.any { it.matches(host, uri.path.orEmpty()) }
+}
+
+private fun AllowedUrlRule.matches(
+    host: String,
+    path: String,
+): Boolean =
+    (host == this.host || (includeSubdomains && host.endsWith(".${this.host}"))) &&
+        (pathPrefix == null || path.startsWith(pathPrefix))
 
 fun toDocsData(docsForFunction: OpenDocsForFunction): DocsData =
     DocsData(

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/util/Constants.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/util/Constants.kt
@@ -1,5 +1,11 @@
 package com.codescene.jetbrains.core.util
 
+data class AllowedUrlRule(
+    val host: String,
+    val includeSubdomains: Boolean = true,
+    val pathPrefix: String? = null,
+)
+
 object Constants {
     const val CODESCENE = "CodeScene"
     const val CODESCENE_SERVER_URL = "https://codescene.io"
@@ -62,16 +68,16 @@ object Constants {
     const val STRING_HEAVY_FUNCTION_ARGUMENTS = "String Heavy Function Arguments"
 
     const val IDE_TYPE = "JetBrains"
-    val ALLOWED_DOMAINS =
+    val ALLOWED_URL_RULES =
         listOf(
-            "https://refactoring.com",
-            "https://en.wikipedia.org",
-            "https://codescene.io",
-            "https://codescene.com",
-            "https://blog.ploeh.dk/2018/08/27/on-constructor-over-injection/",
-            "https://supporthub.codescene.com",
-            "https://helpcenter.codescene.com",
-            "https://forms.clickup.com",
+            AllowedUrlRule("refactoring.com"),
+            AllowedUrlRule("en.wikipedia.org"),
+            AllowedUrlRule("codescene.io"),
+            AllowedUrlRule("codescene.com"),
+            AllowedUrlRule("blog.ploeh.dk", pathPrefix = "/2018/08/27/on-constructor-over-injection/"),
+            AllowedUrlRule("supporthub.codescene.com"),
+            AllowedUrlRule("helpcenter.codescene.com"),
+            AllowedUrlRule("forms.clickup.com"),
         )
     const val DELTA_ANALYSIS_JOB = "deltaAnalysis"
     const val AUTO_REFACTOR_JOB = "autoRefactor"

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/handler/CwfActionLogicTest.kt
@@ -96,10 +96,46 @@ class CwfActionLogicTest {
     }
 
     @Test
-    fun `isUrlAllowed validates allowed domain and non blank`() {
-        assertEquals(true, isUrlAllowed("https://codescene.io/docs/page"))
-        assertEquals(false, isUrlAllowed("https://example.com"))
-        assertEquals(false, isUrlAllowed(""))
+    fun `isUrlAllowed accepts known allowed https destinations`() {
+        val allowedUrls =
+            listOf(
+                "https://codescene.io/docs/page",
+                "https://docs.codescene.io/page",
+                "https://codescene.com/product/free-trial",
+                "https://supporthub.codescene.com/kb-tickets/new",
+                "https://helpcenter.codescene.com/articles/a",
+                "https://forms.clickup.com/form/a",
+                "https://refactoring.com/catalog/replaceTempWithQuery.html",
+                "https://en.wikipedia.org/wiki/Code_smell",
+                "https://blog.ploeh.dk/2018/08/27/on-constructor-over-injection/",
+            )
+
+        allowedUrls.forEach { url ->
+            assertEquals(url, true, isUrlAllowed(url))
+        }
+    }
+
+    @Test
+    fun `isUrlAllowed rejects malformed and bypass URLs`() {
+        val rejectedUrls =
+            listOf(
+                "https://example.com",
+                "https://codescene.io.evil.com/foo",
+                "https://codescene.io@evil.test",
+                "http://codescene.io",
+                "https://codescene.io:444/foo",
+                "",
+                "   ",
+                "/relative/path",
+                "not a url",
+                "https:///missing-host",
+                "https://codescene.io.",
+                "https://blog.ploeh.dk/2018/08/27/other-article/",
+            )
+
+        rejectedUrls.forEach { url ->
+            assertEquals(url, false, isUrlAllowed(url))
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Replace prefix-based CWF URL allow-list validation with structured URI validation. This blocks host/userinfo phishing trampoline bypasses before WebView-originated links are opened in the user's browser.

## Ticket

https://app.clickup.com/t/86c9rpq9r

## Changes

- Added host/path based allowed URL rules for CWF links.
- Replaced `startsWith` URL validation with `java.net.URI` parsing and structural checks for scheme, host, userinfo, and port.
- Preserved the path-specific Ploeh article allow-list behavior.
- Expanded `CwfActionLogicTest` with allowed destination coverage and regression cases for bypass/malformed URLs.

## Testing

- `./gradlew :core:test --tests com.codescene.jetbrains.core.handler.CwfActionLogicTest --no-daemon`
- `make iter`

## Acceptance Criteria

- [x] `isUrlAllowed` rejects prefix-bypass hosts such as `https://codescene.io.evil.com/foo`.
- [x] `isUrlAllowed` rejects userinfo bypasses such as `https://codescene.io@evil.test`.
- [x] `isUrlAllowed` requires `https`.
- [x] `isUrlAllowed` rejects unexpected explicit ports.
- [x] `isUrlAllowed` rejects blank, malformed, relative, and hostless URLs.
- [x] `isUrlAllowed` allows intended CodeScene and known external allowed destinations.
- [x] Existing browser-opening behavior remains unchanged for URLs that pass validation.