### PR TITLE
CS-11207: Redact and scope unhandled-error telemetry

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/telemetry/UnhandledErrorReport.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/telemetry/UnhandledErrorReport.kt
@@ -1,0 +1,46 @@
+package com.codescene.jetbrains.core.telemetry
+
+private const val MAX_STACK_FRAMES = 25
+private const val CODESCENE_STACK_PREFIX = "com.codescene."
+private val TOKEN_PATTERN = Regex("[A-Za-z0-9_-]{20,}")
+
+fun isOriginatingFromCodescene(throwable: Throwable): Boolean {
+    val frame = throwable.stackTrace.firstOrNull() ?: return false
+    return frame.className.startsWith(CODESCENE_STACK_PREFIX)
+}
+
+fun buildUnhandledErrorPayload(
+    throwable: Throwable,
+    pathPrefixesToRedact: List<String> = emptyList(),
+    extraData: Map<String, Any> = emptyMap(),
+): Map<String, Any> {
+    val sanitizedPrefixes = pathPrefixesToRedact.filter { it.isNotBlank() }.distinct()
+    return buildMap {
+        put("name", throwable::class.java.name)
+        put("message", redactSensitiveText(throwable.message ?: "", sanitizedPrefixes))
+        put("stack", redactSensitiveText(truncateStackTrace(throwable), sanitizedPrefixes))
+        if (extraData.isNotEmpty()) put("extraData", extraData)
+    }
+}
+
+fun redactSensitiveText(
+    text: String,
+    pathPrefixesToRedact: List<String>,
+): String {
+    var result = text
+    pathPrefixesToRedact
+        .sortedByDescending { it.length }
+        .forEach { prefix -> result = result.replace(prefix, "<redacted>") }
+    val userHome = System.getProperty("user.home")
+    if (!userHome.isNullOrEmpty()) {
+        result = result.replace(userHome, "<redacted>")
+    }
+    return TOKEN_PATTERN.replace(result) { "<redacted>" }
+}
+
+fun truncateStackTrace(throwable: Throwable): String {
+    val lines = throwable.stackTraceToString().lines()
+    if (lines.size <= MAX_STACK_FRAMES) return lines.joinToString("\n")
+    val omitted = lines.size - MAX_STACK_FRAMES
+    return lines.take(MAX_STACK_FRAMES).joinToString("\n") + "\n\t... $omitted more"
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/telemetry/UnhandledErrorReportTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/telemetry/UnhandledErrorReportTest.kt
@@ -1,0 +1,90 @@
+package com.codescene.jetbrains.core.telemetry
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UnhandledErrorReportTest {
+    @Test
+    fun `isOriginatingFromCodescene accepts top frame in plugin package`() {
+        assertTrue(isOriginatingFromCodescene(CodesceneCausedException()))
+    }
+
+    @Test
+    fun `isOriginatingFromCodescene rejects foreign plugin frames`() {
+        assertFalse(isOriginatingFromCodescene(ForeignPluginException()))
+    }
+
+    @Test
+    fun `redactSensitiveText masks user home project paths and tokens`() {
+        val home = System.getProperty("user.home") ?: ""
+        val projectPath = "$home/project"
+        val raw = "path=$projectPath token=abcdefghijklmnopqrstuvwxyz"
+        val redacted = redactSensitiveText(raw, listOf(projectPath))
+        assertEquals("path=<redacted> token=<redacted>", redacted)
+    }
+
+    @Test
+    fun `truncateStackTrace caps frame count`() {
+        val deep = DeepCodesceneException()
+        val stack = truncateStackTrace(deep)
+        assertTrue(stack.contains("more"))
+        assertTrue(stack.lines().size < deep.stackTrace.size + 2)
+    }
+
+    @Test
+    fun `buildUnhandledErrorPayload redacts message and stack`() {
+        val home = System.getProperty("user.home") ?: ""
+        val secretPath = "$home/my-project"
+        val error = CodesceneCausedException("failed at $secretPath")
+        val payload = buildUnhandledErrorPayload(error, listOf(secretPath))
+        assertEquals("failed at <redacted>", payload["message"])
+        assertTrue((payload["stack"] as String).contains("<redacted>"))
+        assertFalse((payload["stack"] as String).contains(home))
+    }
+
+    private class CodesceneCausedException(
+        message: String? = null,
+    ) : RuntimeException(message) {
+        init {
+            stackTrace =
+                arrayOf(
+                    StackTraceElement(
+                        "com.codescene.jetbrains.core.SomeClass",
+                        "run",
+                        "SomeClass.kt",
+                        1,
+                    ),
+                )
+        }
+    }
+
+    private class ForeignPluginException : RuntimeException() {
+        init {
+            stackTrace =
+                arrayOf(
+                    StackTraceElement(
+                        "com.other.plugin.SomeClass",
+                        "run",
+                        "SomeClass.kt",
+                        1,
+                    ),
+                )
+        }
+    }
+
+    private class DeepCodesceneException : RuntimeException() {
+        init {
+            stackTrace =
+                Array(35) { index ->
+                    StackTraceElement(
+                        "com.codescene.jetbrains.core.Deep",
+                        "frame$index",
+                        "Deep.kt",
+                        index,
+                    )
+                }
+        }
+    }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/RecordingTelemetryService.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/RecordingTelemetryService.kt
@@ -1,6 +1,7 @@
 package com.codescene.jetbrains.core.testdoubles
 
 import com.codescene.jetbrains.core.contracts.ITelemetryService
+import com.codescene.jetbrains.core.telemetry.buildUnhandledErrorPayload
 import com.codescene.jetbrains.core.util.TelemetryEvents
 
 class RecordingTelemetryService : ITelemetryService {
@@ -19,12 +20,7 @@ class RecordingTelemetryService : ITelemetryService {
     ) {
         logUsage(
             TelemetryEvents.UNHANDLED_ERROR,
-            buildMap {
-                put("name", throwable::class.java.name)
-                put("message", throwable.message ?: "")
-                put("stack", throwable.stackTraceToString())
-                if (extraData.isNotEmpty()) put("extraData", extraData)
-            },
+            buildUnhandledErrorPayload(throwable, emptyList(), extraData),
         )
     }
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/telemetry/GlobalUncaughtErrorTelemetry.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/telemetry/GlobalUncaughtErrorTelemetry.kt
@@ -1,5 +1,6 @@
 package com.codescene.jetbrains.platform.telemetry
 
+import com.codescene.jetbrains.core.telemetry.isOriginatingFromCodescene
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.Key
 
@@ -15,7 +16,9 @@ fun installGlobalUncaughtErrorTelemetry() {
     app.putUserData(UNCAUGHT_TELEMETRY_INSTALLED, true)
     Thread.setDefaultUncaughtExceptionHandler { thread, exception ->
         try {
-            TelemetryService.getInstance().logUnhandledError(exception, emptyMap())
+            if (isOriginatingFromCodescene(exception)) {
+                TelemetryService.getInstance().logUnhandledError(exception, emptyMap())
+            }
         } catch (_: Throwable) {
         }
         previous?.uncaughtException(thread, exception)

--- a/src/main/kotlin/com/codescene/jetbrains/platform/telemetry/TelemetryPathRedaction.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/telemetry/TelemetryPathRedaction.kt
@@ -1,0 +1,6 @@
+package com.codescene.jetbrains.platform.telemetry
+
+import com.intellij.openapi.project.ProjectManager
+
+internal fun openProjectPathPrefixes(): List<String> =
+    ProjectManager.getInstance().openProjects.mapNotNull { it.basePath }.distinct()

--- a/src/main/kotlin/com/codescene/jetbrains/platform/telemetry/TelemetryService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/telemetry/TelemetryService.kt
@@ -7,6 +7,7 @@ import com.codescene.jetbrains.core.flag.RuntimeFlags
 import com.codescene.jetbrains.core.review.BaseService
 import com.codescene.jetbrains.core.telemetry.TelemetryRequest
 import com.codescene.jetbrains.core.telemetry.UnhandledErrorTelemetry
+import com.codescene.jetbrains.core.telemetry.buildUnhandledErrorPayload
 import com.codescene.jetbrains.core.telemetry.normalizeIdeName
 import com.codescene.jetbrains.core.telemetry.resolveTelemetryEventData
 import com.codescene.jetbrains.core.util.TelemetryEvents
@@ -97,12 +98,11 @@ class TelemetryService : BaseService(Log), Disposable, ITelemetryService {
         if (!settings.telemetryConsentGiven || !settings.telemetryNoticeShown) return
         if (!UnhandledErrorTelemetry.trySend()) return
         val payload =
-            buildMap<String, Any> {
-                put("name", throwable::class.java.name)
-                put("message", throwable.message ?: "")
-                put("stack", throwable.stackTraceToString())
-                if (extraData.isNotEmpty()) put("extraData", extraData)
-            }
+            buildUnhandledErrorPayload(
+                throwable,
+                openProjectPathPrefixes(),
+                extraData,
+            )
         logUsage(TelemetryEvents.UNHANDLED_ERROR, payload)
     }
 


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpr0e (CS-11207)

## Problem
Unhandled-error telemetry sent full stack traces and messages (paths, tokens, other plugins) via a global uncaught handler.

## Fix
- Report only when top stack frame is in `com.codescene.*` (global handler still forwards to previous handler).
- Redact user home, open project roots, and token-shaped strings; truncate stacks to 25 frames.
- Core `UnhandledErrorReport` + platform project path collection.

## Test plan
- [x] `gradlew` ktlint + test + buildPlugin
- [x] CodeScene MCP (analyze_change_set, pre_commit safeguard, file review)
- [x] Manual: trigger CodeScene exception with telemetry on; confirm payload has no raw paths/tokens

Made with [Cursor](https://cursor.com)