### PR TITLE
CS-11209: Guard CWF message JSON decode in onQuery

### DIFF
--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/handler/CwfMessageHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/handler/CwfMessageHandler.kt
@@ -78,7 +78,14 @@ class CwfMessageHandler(
                 ignoreUnknownKeys = true
             }
 
-        val message = json.decodeFromString<CwfMessage>(request)
+        val message =
+            try {
+                json.decodeFromString<CwfMessage>(request)
+            } catch (e: Throwable) {
+                Log.warn("Failed to parse CWF message: ${e.message}", serviceName)
+                callback?.failure(0, "Invalid message.")
+                return true
+            }
         val processed = routeCwfMessage(message, this, json)
         if (!processed) {
             Log.warn("Message could not be processed: ${message.messageType}", serviceName)


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpr1w (CS-11209)

## Problem
Malformed CWF payloads passed to cefQuery caused unhandled SerializationException from json.decodeFromString, which could break the JS bridge and surface in global uncaught-exception telemetry.

## Fix
Wrap CWF message JSON decode in onQuery with try/catch; log a warning and return callback.failure for invalid input instead of propagating parse errors.

## Test plan
- [x] Send junk via CWF bridge; expect failed query, no uncaught exception in telemetry
- [x] gradlew ktlint + test passed; CodeScene MCP (nalyze_change_set, per-file review) run

Made with [Cursor](https://cursor.com)