### PR TITLE
CS-11216: Redact absolute paths in debug logs

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitPathUtils.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitPathUtils.kt
@@ -28,6 +28,13 @@ fun pathCacheKey(path: String): String = pathComparisonKey(path)
 
 fun pathFileName(path: String): String = path.replace('\\', '/').substringAfterLast('/')
 
+const val LOG_FULL_PATHS_PROPERTY = "codescene.diagnostics.logFullPaths"
+
+fun logFullPathsEnabled(): Boolean =
+    System.getProperty(LOG_FULL_PATHS_PROPERTY)?.equals("true", ignoreCase = true) == true
+
+fun pathForLog(path: String): String = if (logFullPathsEnabled()) path else pathFileName(path)
+
 fun isPathUnderRoot(
     path: String,
     rootPath: String,

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitPathUtilsTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitPathUtilsTest.kt
@@ -128,4 +128,35 @@ class GitPathUtilsTest {
         val path = "C:\\test\\file.kt"
         assertEquals(pathComparisonKey(path), pathCacheKey(path))
     }
+
+    @Test
+    fun `pathForLog returns basename by default`() {
+        val previous = System.getProperty(LOG_FULL_PATHS_PROPERTY)
+        try {
+            System.clearProperty(LOG_FULL_PATHS_PROPERTY)
+            assertEquals("Main.kt", pathForLog("C:/Users/dev/project/src/Main.kt"))
+        } finally {
+            if (previous == null) {
+                System.clearProperty(LOG_FULL_PATHS_PROPERTY)
+            } else {
+                System.setProperty(LOG_FULL_PATHS_PROPERTY, previous)
+            }
+        }
+    }
+
+    @Test
+    fun `pathForLog returns full path when diagnostics property is true`() {
+        val previous = System.getProperty(LOG_FULL_PATHS_PROPERTY)
+        try {
+            System.setProperty(LOG_FULL_PATHS_PROPERTY, "true")
+            val fullPath = "C:/Users/dev/project/src/Main.kt"
+            assertEquals(fullPath, pathForLog(fullPath))
+        } finally {
+            if (previous == null) {
+                System.clearProperty(LOG_FULL_PATHS_PROPERTY)
+            } else {
+                System.setProperty(LOG_FULL_PATHS_PROPERTY, previous)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/AceService.kt
@@ -8,6 +8,7 @@ import com.codescene.data.ace.RefactoringOptions
 import com.codescene.data.delta.Delta
 import com.codescene.data.review.Review
 import com.codescene.jetbrains.core.contracts.IAceService
+import com.codescene.jetbrains.core.git.pathForLog
 import com.codescene.jetbrains.core.review.AcePreflightOrchestrator
 import com.codescene.jetbrains.core.review.AceRefactorableFunctionCacheEntry
 import com.codescene.jetbrains.core.review.AceRefactoringOrchestrator
@@ -48,7 +49,7 @@ internal sealed class RefactorableFunctionsSource {
             review.fileLevelCodeSmells + review.functionLevelCodeSmells.flatMap { it.codeSmells }
         }
 
-        override fun analysisLabel(): String = "review with $codeSmells"
+        override fun analysisLabel(): String = "review with ${codeSmells.size} code smell(s)"
 
         override fun fetch(
             params: CodeParams,
@@ -105,7 +106,7 @@ class AceService :
         source: RefactorableFunctionsSource,
     ): Boolean {
         Log.debug(
-            "Getting refactorable functions for $filePath based on ${source.analysisLabel()}...",
+            "Getting refactorable functions for ${pathForLog(filePath)} based on ${source.analysisLabel()}...",
             serviceImplementation,
         )
         return refactorableFunctionsHandler(project, filePath, currentCode) {

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/PathBasedReviewHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/PathBasedReviewHandler.kt
@@ -37,7 +37,7 @@ class PathBasedReviewHandler(private val project: Project) {
         val startTime = System.currentTimeMillis()
         val file = LocalFileSystem.getInstance().findFileByPath(filePath)
         if (file == null) {
-            Log.info("reviewByPath file not found path=$filePath", "CodeSceneCachedReview")
+            Log.info("reviewByPath file not found file=$fileName", "CodeSceneCachedReview")
             return
         }
 
@@ -61,7 +61,7 @@ class PathBasedReviewHandler(private val project: Project) {
                 }
             }
         if (currentCode == null) {
-            Log.info("reviewByPath file became invalid path=$filePath", "CodeSceneCachedReview")
+            Log.info("reviewByPath file became invalid file=$fileName", "CodeSceneCachedReview")
             return
         }
         Log.info(
@@ -82,14 +82,14 @@ class PathBasedReviewHandler(private val project: Project) {
 
             if (deltaHit) {
                 Log.info(
-                    "reviewByPath full cache hit path=$filePath totalTime=${System.currentTimeMillis() - startTime}ms",
+                    "reviewByPath full cache hit file=$fileName totalTime=${System.currentTimeMillis() - startTime}ms",
                     "CodeSceneCachedReview",
                 )
                 return
             }
 
             Log.info(
-                "reviewByPath review cache hit, delta miss path=$filePath",
+                "reviewByPath review cache hit, delta miss file=$fileName",
                 "CodeSceneCachedReview",
             )
             handleDeltaByPath(filePath, fileName, currentCode, cachedReview.score.orElse(null), reviewMiss = false)
@@ -107,14 +107,14 @@ class PathBasedReviewHandler(private val project: Project) {
             "CodeSceneCachedReview",
         )
         if (review == null) {
-            Log.info("reviewByPath no result path=$filePath", "CodeSceneCachedReview")
+            Log.info("reviewByPath no result file=$fileName", "CodeSceneCachedReview")
             return
         }
 
         refreshAceFromReview(project, filePath, fileName, currentCode, review)
 
         Log.info(
-            "reviewByPath completed path=$filePath totalTime=${System.currentTimeMillis() - startTime}ms",
+            "reviewByPath completed file=$fileName totalTime=${System.currentTimeMillis() - startTime}ms",
             "CodeSceneCachedReview",
         )
         handleDeltaByPath(filePath, fileName, currentCode, review.score.orElse(null), reviewMiss = true)


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rpruw (CS-11216)

## Problem
Debug and review logging wrote absolute file paths and code-smell details into idea.log, which often ships in support bundles (CWE-200).

## Fix
- Added `pathForLog()` in core (basename by default; full path when `-Dcodescene.diagnostics.logFullPaths=true`).
- AceService debug uses basename; review source label logs smell count only.
- PathBasedReviewHandler info logs use `file=` basename instead of full paths.

## Test plan
- [x] Enable CodeScene debug logging; confirm idea.log shows basenames only.
- [x] Optional: run IDE with `-Dcodescene.diagnostics.logFullPaths=true` to verify full paths when explicitly enabled.
- [x] `gradlew` format/check + test passed; CodeScene MCP (`analyze_change_set`, per-file reviews) run