### PR TITLE
CS-11215: Escape theme CSS font-family for safe embedding

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/util/CwfThemeCssUtils.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/util/CwfThemeCssUtils.kt
@@ -52,6 +52,35 @@ data class CwfThemeCssInputs(
 
 fun toHex(color: RgbColor): String = "%02X%02X%02X".format(color.red, color.green, color.blue)
 
+fun escapeCssSingleQuotedString(value: String): String {
+    val body =
+        buildString(value.length * 2) {
+            value.forEach { ch ->
+                when (ch) {
+                    '\\' -> {
+                        append('\\')
+                        append('\\')
+                    }
+                    '\'' -> {
+                        append('\\')
+                        append('\'')
+                    }
+                    '<' -> {
+                        append('\\')
+                        append("3c ")
+                    }
+                    '\n', '\r', '\u000C' -> {
+                        append('\\')
+                        append('A')
+                        append(' ')
+                    }
+                    else -> append(ch)
+                }
+            }
+        }
+    return "'$body'"
+}
+
 fun buildCwfThemeCssVariables(inputs: CwfThemeSourceInputs): String =
     buildCwfThemeCssVariables(
         CwfThemeCssInputs(
@@ -89,7 +118,7 @@ fun buildCwfThemeCssVariables(inputs: CwfThemeCssInputs): String {
     sb.appendLine("  --cs-theme-textCodeBlock-background: #$editorBg;")
     sb.appendLine("  --cs-theme-scroll-bar-thumb: #$scrollbarThumbHex;")
     sb.appendLine("  --cs-theme-font-size: ${fontSize}px;")
-    sb.appendLine("  --cs-theme-editor-font-family: '$editorFontFamily', monospace;")
+    sb.appendLine("  --cs-theme-editor-font-family: ${escapeCssSingleQuotedString(editorFontFamily)}, monospace;")
     sb.appendLine("  --cs-theme-editor-font-size: ${editorFontSize}px;")
     sb.appendLine("  --cs-theme-button-foreground: #$buttonFg;")
     sb.appendLine("  --cs-theme-button-background: #$buttonBg;")

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/util/CwfThemeCssUtilsTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/util/CwfThemeCssUtilsTest.kt
@@ -47,6 +47,42 @@ class CwfThemeCssUtilsTest {
     }
 
     @Test
+    fun `escapeCssSingleQuotedString escapes quotes and angle brackets`() {
+        assertEquals(
+            "'Evil\\'; color: red; /*'",
+            escapeCssSingleQuotedString("Evil'; color: red; /*"),
+        )
+        assertEquals(
+            "'Font\\3c /style>'",
+            escapeCssSingleQuotedString("Font</style>"),
+        )
+    }
+
+    @Test
+    fun `buildCwfThemeCssVariables escapes hostile editor font family`() {
+        val css =
+            buildCwfThemeCssVariables(
+                CwfThemeCssInputs(
+                    textForegroundHex = "111111",
+                    linkForegroundHex = "222222",
+                    buttonForegroundHex = "333333",
+                    buttonBackgroundHex = "444444",
+                    editorBackgroundHex = "555555",
+                    scrollbarThumbHex = "66666666",
+                    buttonSecondaryBackgroundHex = "777777",
+                    fontSizePx = 12,
+                    editorFontFamily = "Evil'; color: red; /*",
+                    editorFontSizePx = 13,
+                ),
+            )
+
+        assertEquals(
+            "  --cs-theme-editor-font-family: 'Evil\\'; color: red; /*', monospace;",
+            css.lines()[8],
+        )
+    }
+
+    @Test
     fun `buildCwfThemeCssVariables produces expected root block`() {
         val inputs =
             CwfThemeCssInputs(

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/util/CwfThemeCssUtilsTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/util/CwfThemeCssUtilsTest.kt
@@ -59,6 +59,21 @@ class CwfThemeCssUtilsTest {
     }
 
     @Test
+    fun `escapeCssSingleQuotedString escapes backslashes`() {
+        assertEquals(
+            "'a\\\\b'",
+            escapeCssSingleQuotedString("""a\b"""),
+        )
+    }
+
+    @Test
+    fun `escapeCssSingleQuotedString escapes line breaks as CSS line feed`() {
+        assertEquals("'a\\A b'", escapeCssSingleQuotedString("a\nb"))
+        assertEquals("'a\\A b'", escapeCssSingleQuotedString("a\rb"))
+        assertEquals("'a\\A b'", escapeCssSingleQuotedString("a\u000Cb"))
+    }
+
+    @Test
     fun `buildCwfThemeCssVariables escapes hostile editor font family`() {
         val css =
             buildCwfThemeCssVariables(


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rprre (CS-11215)

## Problem
Theme CSS interpolated editor font-family without escaping; hostile values could break CSS declarations or HTML `</style>` breakout when theme CSS is embedded.

## Fix
- Add `escapeCssSingleQuotedString` in `CwfThemeCssUtils` and use it for `--cs-theme-editor-font-family`. Escapes quotes, backslashes, angle brackets, and line breaks.
- Theme live-update JS path already uses `JsEmbedEscapes.toJsStringLiteral` (JSON.stringify) on master.

## Test plan
- [x] `gradlew` ktlint + test + buildPlugin
- [x] CodeScene MCP (`analyze_change_set`, per-file review, pre-commit safeguard)
- [x] Manual: switch IDE theme with unusual editor font if available

Made with [Cursor](https://cursor.com)