### PR TITLE
CS-11212: Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947
         with:
           gradle-home-cache-excludes: |
             caches/modules-2/files-2.1/idea/**
@@ -43,7 +43,7 @@ jobs:
         run: ./gradlew :benchmarks:jmh
 
       - name: Store ExtensionAPI benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba
         with:
           name: JetBrains Plugin - ExtensionAPI
           tool: 'jmh'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
     steps:
       - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: true
           large-packages: true
@@ -51,7 +51,7 @@ jobs:
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@48b5f213c81028ace310571dc5ec0fbbca0b2947
 
       # Set up Java environment for the next steps
       - name: Setup Java
@@ -62,7 +62,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947
         with:
           gradle-home-cache-excludes: |
             caches/modules-2/files-2.1/idea/**
@@ -121,7 +121,7 @@ jobs:
     steps:
       - name: Maximize Build Space
         if: matrix.os == 'ubuntu-latest'
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: true
           large-packages: true
@@ -141,7 +141,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947
         with:
           cache-read-only: true
           gradle-home-cache-excludes: |
@@ -154,7 +154,7 @@ jobs:
 
       - name: Publish Test Results
         if: ${{ always() && !cancelled() && matrix.os == 'ubuntu-latest' }}
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040
         with:
           files: "**/build/test-results/test/**/*.xml"
 
@@ -184,7 +184,7 @@ jobs:
     steps:
       # Free GitHub Actions Environment Disk Space
       - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: true
           large-packages: true
@@ -202,7 +202,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947
         with:
           cache-read-only: true
           gradle-home-cache-excludes: |
@@ -277,7 +277,7 @@ jobs:
 
       # Run dependency check
       - name: Depcheck
-        uses: dependency-check/Dependency-Check_Action@main
+        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c
         id: Depcheck
         with:
           project: "codescene-jetbrains"
@@ -291,7 +291,7 @@ jobs:
       # Upload dependency check report
       - name: Upload Test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: Dependency check report
           path: ${{github.workspace}}/reports/dependency-check-report.html

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -27,7 +27,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947
 
       - name: Run tests with merged coverage
         run: ./gradlew fetchCwf jacocoMergedReport -PFEATURE_CWF_DEVMODE=${{ secrets.FEATURE_CWF_DEVMODE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: true
           large-packages: true
@@ -35,7 +35,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947
 
       - name: Resolve Release Metadata
         id: release
@@ -76,7 +76,7 @@ jobs:
         run: ./gradlew publishPlugin -PreleaseVersion=${{ steps.release.outputs.version }} -PFEATURE_CWF_DEVMODE=${{ secrets.FEATURE_CWF_DEVMODE }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947
 
       # Run IDEA prepared for UI testing
       - name: Run IDE
@@ -52,7 +52,7 @@ jobs:
 
       # Wait for IDEA to be started
       - name: Health Check
-        uses: jtalk/url-health-check-action@v4
+        uses: jtalk/url-health-check-action@b716ccb6645355dd9fcce8002ce460e5474f7f00
         with:
           url: http://127.0.0.1:8082
           max-attempts: 15


### PR DESCRIPTION
## ClickUp
https://app.clickup.com/t/86c9rprfy (CS-11212)

## Problem
Third-party GitHub Actions were pinned to mutable refs (@main, @master, or floating major tags), allowing supply-chain drift if a tag or branch is retargeted.

## Fix
Pin all third-party actions to full commit SHAs across build, release, benchmarks, run-ui-tests, and code-coverage workflows. Replaced actions/upload-artifact@master with the v4 release SHA. Official actions/* remain on @v4 per GitHub guidance. Existing Dependabot github-actions config will keep SHAs current.

## Test plan
- [x] gradlew ktlintFormat / ktlintCheck, buildPlugin, test passed locally
- [x] CodeScene MCP analyze_change_set and pre_commit_code_health_safeguard passed
- [ ] CI Build workflow green on PR

Made with [Cursor](https://cursor.com)