### PR TITLE
CS-11401: Improve baseline branch detection (origin/HEAD + .codescene/config.json)

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/ClosestMainLineMergeBase.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/ClosestMainLineMergeBase.kt
@@ -5,10 +5,13 @@ val MAIN_LINE_BRANCH_NAMES =
 
 fun mainLineRefsInProbeOrder(): List<String> = MAIN_LINE_BRANCH_NAMES.flatMap { listOf(it, "origin/$it") }
 
-fun collectOrderedUniqueMergeBases(mergeBaseForRef: (ref: String) -> String?): List<String> {
+fun collectOrderedUniqueMergeBases(
+    refs: List<String>,
+    mergeBaseForRef: (ref: String) -> String?,
+): List<String> {
     val ordered = mutableListOf<String>()
     val seen = mutableSetOf<String>()
-    for (ref in mainLineRefsInProbeOrder()) {
+    for (ref in refs) {
         val sha = mergeBaseForRef(ref)?.trim()?.takeIf { it.isNotEmpty() } ?: continue
         if (seen.add(sha)) {
             ordered.add(sha)
@@ -38,7 +41,8 @@ fun selectClosestMergeBase(
 fun resolveClosestMainLineMergeBase(
     isAncestor: (ancestor: String, descendant: String) -> Boolean,
     mergeBaseForRef: (ref: String) -> String?,
+    refs: List<String> = mainLineRefsInProbeOrder(),
 ): String? {
-    val ordered = collectOrderedUniqueMergeBases(mergeBaseForRef)
+    val ordered = collectOrderedUniqueMergeBases(refs, mergeBaseForRef)
     return selectClosestMergeBase(ordered, isAncestor)
 }

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/CodesceneRepoConfig.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/CodesceneRepoConfig.kt
@@ -1,0 +1,21 @@
+package com.codescene.jetbrains.core.git
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+private val configJson = Json { ignoreUnknownKeys = true }
+
+fun parseBaselineBranchFromConfig(jsonText: String?): String? {
+    if (jsonText.isNullOrBlank()) return null
+    return runCatching {
+        configJson
+            .parseToJsonElement(jsonText.trim())
+            .jsonObject["baseline_branch"]
+            ?.jsonPrimitive
+            ?.contentOrNull
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+    }.getOrNull()
+}

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitChangeObserver.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitChangeObserver.kt
@@ -33,6 +33,9 @@ class GitChangeObserver(
 
     suspend fun populateTrackerFromRepoState() {
         logger.info("Populating tracker from repo state", "GitChangeObserver")
+        synchronized(tracker) {
+            tracker.clear()
+        }
         val changedFiles = gitChangeLister.getAllChangedFiles(gitRootPath, workspacePath, emptySet())
         logger.info("getAllChangedFiles returned ${changedFiles.size} files", "GitChangeObserver")
         for (absolutePath in changedFiles) {

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/MainLineBranchContext.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/MainLineBranchContext.kt
@@ -1,0 +1,54 @@
+package com.codescene.jetbrains.core.git
+
+data class MainLineBranchContext(
+    val configuredBaseline: String? = null,
+    val defaultBranchFromOriginHead: String? = null,
+    val localBranchNames: Set<String> = emptySet(),
+) {
+    fun isMainLineBranch(branchName: String): Boolean {
+        val normalized = branchName.trim()
+        if (normalized.isEmpty()) return false
+
+        configuredBaseline?.let { baseline ->
+            return normalized.equals(baseline, ignoreCase = true)
+        }
+
+        defaultBranchFromOriginHead?.let { defaultBranch ->
+            return normalized.equals(defaultBranch, ignoreCase = true)
+        }
+
+        return MAIN_LINE_BRANCH_NAMES.any { it.equals(normalized, ignoreCase = true) }
+    }
+
+    fun refsForMergeBaseProbe(): List<String> {
+        val refs = linkedSetOf<String>()
+
+        configuredBaseline?.let {
+            appendBranchRefs(refs, it)
+            return refs.toList()
+        }
+
+        defaultBranchFromOriginHead?.let {
+            appendBranchRefs(refs, it)
+            return refs.toList()
+        }
+
+        val fallbackBranches =
+            MAIN_LINE_BRANCH_NAMES.filter { name ->
+                localBranchNames.any { local -> local.equals(name, ignoreCase = true) }
+            }
+        for (branch in fallbackBranches) {
+            appendBranchRefs(refs, branch)
+        }
+
+        return refs.toList()
+    }
+
+    private fun appendBranchRefs(
+        refs: LinkedHashSet<String>,
+        branchName: String,
+    ) {
+        refs.add(branchName)
+        refs.add("origin/$branchName")
+    }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/ClosestMainLineMergeBaseTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/ClosestMainLineMergeBaseTest.kt
@@ -47,8 +47,9 @@ class ClosestMainLineMergeBaseTest {
     @Test
     fun `collectOrderedUniqueMergeBases preserves probe order and dedupes`() {
         val seen = mutableListOf<String>()
+        val refs = listOf("main", "origin/main", "master", "origin/master")
         val bases =
-            collectOrderedUniqueMergeBases { ref ->
+            collectOrderedUniqueMergeBases(refs) { ref ->
                 seen.add(ref)
                 when (ref) {
                     "main" -> "sha1"

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/CodesceneRepoConfigTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/CodesceneRepoConfigTest.kt
@@ -1,0 +1,29 @@
+package com.codescene.jetbrains.core.git
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CodesceneRepoConfigTest {
+    @Test
+    fun `parseBaselineBranchFromConfig returns branch when present`() {
+        assertEquals("develop", parseBaselineBranchFromConfig("""{"baseline_branch":"develop"}"""))
+    }
+
+    @Test
+    fun `parseBaselineBranchFromConfig ignores unknown keys`() {
+        assertEquals(
+            "main",
+            parseBaselineBranchFromConfig("""{"baseline_branch":"main","other":1}"""),
+        )
+    }
+
+    @Test
+    fun `parseBaselineBranchFromConfig returns null for blank or invalid`() {
+        assertNull(parseBaselineBranchFromConfig(null))
+        assertNull(parseBaselineBranchFromConfig(""))
+        assertNull(parseBaselineBranchFromConfig("{}"))
+        assertNull(parseBaselineBranchFromConfig("not json"))
+        assertNull(parseBaselineBranchFromConfig("""{"baseline_branch":""}"""))
+    }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverPrePopulationTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverPrePopulationTest.kt
@@ -94,6 +94,24 @@ class GitChangeObserverPrePopulationTest {
         }
 
     @Test
+    fun `repopulate clears stale tracker entries`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles = setOf("$workspacePath/src/old.ts")
+
+            val observer = createObserver()
+            observer.populateTrackerFromRepoState()
+            assertTrue(observer.getTrackedFiles().contains("/workspace/src/old.ts"))
+
+            mockGitChangeLister.changedFiles = setOf("$workspacePath/src/new.ts")
+            observer.populateTrackerFromRepoState()
+
+            val trackedFiles = observer.getTrackedFiles()
+            assertFalse(trackedFiles.contains("/workspace/src/old.ts"))
+            assertTrue(trackedFiles.contains("/workspace/src/new.ts"))
+            assertEquals(1, trackedFiles.size)
+        }
+
+    @Test
     fun `pre-population handles empty changed files list`() =
         runBlocking {
             mockGitChangeLister.changedFiles = emptySet()

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/MainLineBranchContextTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/MainLineBranchContextTest.kt
@@ -1,0 +1,69 @@
+package com.codescene.jetbrains.core.git
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MainLineBranchContextTest {
+    @Test
+    fun `isMainLineBranch uses configured baseline only`() {
+        val ctx =
+            MainLineBranchContext(
+                configuredBaseline = "develop",
+                defaultBranchFromOriginHead = "main",
+                localBranchNames = setOf("main", "develop", "master"),
+            )
+        assertTrue(ctx.isMainLineBranch("develop"))
+        assertFalse(ctx.isMainLineBranch("main"))
+        assertFalse(ctx.isMainLineBranch("master"))
+    }
+
+    @Test
+    fun `isMainLineBranch uses origin default when no config`() {
+        val ctx =
+            MainLineBranchContext(
+                defaultBranchFromOriginHead = "main",
+                localBranchNames = setOf("main", "develop", "master"),
+            )
+        assertTrue(ctx.isMainLineBranch("main"))
+        assertFalse(ctx.isMainLineBranch("develop"))
+    }
+
+    @Test
+    fun `isMainLineBranch falls back to static list when no default`() {
+        val ctx = MainLineBranchContext(localBranchNames = setOf("master"))
+        assertTrue(ctx.isMainLineBranch("master"))
+        assertFalse(ctx.isMainLineBranch("feature"))
+    }
+
+    @Test
+    fun `refsForMergeBaseProbe returns only configured baseline refs`() {
+        val ctx =
+            MainLineBranchContext(
+                configuredBaseline = "develop",
+                defaultBranchFromOriginHead = "main",
+                localBranchNames = setOf("main", "develop"),
+            )
+        assertEquals(listOf("develop", "origin/develop"), ctx.refsForMergeBaseProbe())
+    }
+
+    @Test
+    fun `refsForMergeBaseProbe returns only origin default when known`() {
+        val ctx =
+            MainLineBranchContext(
+                defaultBranchFromOriginHead = "main",
+                localBranchNames = setOf("main", "develop"),
+            )
+        assertEquals(listOf("main", "origin/main"), ctx.refsForMergeBaseProbe())
+    }
+
+    @Test
+    fun `refsForMergeBaseProbe uses local static names when no default`() {
+        val ctx = MainLineBranchContext(localBranchNames = setOf("master", "feature"))
+        assertEquals(
+            listOf("master", "origin/master"),
+            ctx.refsForMergeBaseProbe(),
+        )
+    }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeLister.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeLister.kt
@@ -144,14 +144,16 @@ class TestGitChangeLister(private val testRepoPath: File) : IGitChangeLister {
 
     private fun getMergeBase(gitRootPath: String): String? {
         val currentBranch = exec("git", "rev-parse", "--abbrev-ref", "HEAD").trim()
+        val mainLineContext = mainLineContextFromTestRepo(testRepoPath)
 
-        if (MAIN_LINE_BRANCH_NAMES.any { it.equals(currentBranch, ignoreCase = true) }) {
+        if (mainLineContext.isMainLineBranch(currentBranch)) {
             return exec("git", "rev-parse", "HEAD").trim()
         }
 
         return resolveClosestMainLineMergeBase(
             isAncestor = { ancestor, descendant -> gitIsAncestor(ancestor, descendant) },
             mergeBaseForRef = { ref -> gitMergeBaseWithRef(currentBranch, ref) },
+            refs = mainLineContext.refsForMergeBaseProbe(),
         )
     }
 

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeListerForCommitted.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestGitChangeListerForCommitted.kt
@@ -48,14 +48,16 @@ class TestGitChangeListerForCommitted(private val testRepoPath: File) : IGitChan
 
     private fun getMergeBase(gitRootPath: String): String? {
         val currentBranch = exec("git", "rev-parse", "--abbrev-ref", "HEAD").trim()
+        val mainLineContext = mainLineContextFromTestRepo(testRepoPath)
 
-        if (MAIN_LINE_BRANCH_NAMES.any { it.equals(currentBranch, ignoreCase = true) }) {
+        if (mainLineContext.isMainLineBranch(currentBranch)) {
             return exec("git", "rev-parse", "HEAD").trim()
         }
 
         return resolveClosestMainLineMergeBase(
             isAncestor = { ancestor, descendant -> gitIsAncestor(ancestor, descendant) },
             mergeBaseForRef = { ref -> gitMergeBaseWithRef(currentBranch, ref) },
+            refs = mainLineContext.refsForMergeBaseProbe(),
         )
     }
 

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestRepoMainLineContext.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/TestRepoMainLineContext.kt
@@ -1,0 +1,55 @@
+package com.codescene.jetbrains.core.git
+
+import java.io.File
+
+fun mainLineContextFromTestRepo(testRepoPath: File): MainLineBranchContext {
+    val configFile = File(testRepoPath, ".codescene/config.json")
+    val configured =
+        if (configFile.isFile) {
+            parseBaselineBranchFromConfig(configFile.readText())
+        } else {
+            null
+        }
+    val originDefault = readOriginHeadBranch(testRepoPath)
+    val localBranches = readLocalBranchNames(testRepoPath)
+    return MainLineBranchContext(
+        configuredBaseline = configured,
+        defaultBranchFromOriginHead = originDefault,
+        localBranchNames = localBranches,
+    )
+}
+
+private fun readOriginHeadBranch(testRepoPath: File): String? {
+    val output =
+        runGit(testRepoPath, "git", "symbolic-ref", "refs/remotes/origin/HEAD").trim()
+    if (output.isEmpty() || output.startsWith("fatal")) return null
+    val prefix = "refs/remotes/origin/"
+    return if (output.startsWith(prefix)) {
+        output.removePrefix(prefix)
+    } else {
+        null
+    }
+}
+
+private fun readLocalBranchNames(testRepoPath: File): Set<String> {
+    val output = runGit(testRepoPath, "git", "for-each-ref", "--format=%(refname:short)", "refs/heads")
+    return output
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .toSet()
+}
+
+private fun runGit(
+    testRepoPath: File,
+    vararg command: String,
+): String {
+    val process =
+        ProcessBuilder(*command)
+            .directory(testRepoPath)
+            .redirectErrorStream(true)
+            .start()
+    val result = process.inputStream.bufferedReader().readText()
+    process.waitFor()
+    return result
+}

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/CodesceneRepoFilesListener.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/CodesceneRepoFilesListener.kt
@@ -1,0 +1,109 @@
+package com.codescene.jetbrains.platform.git
+
+import com.codescene.jetbrains.core.git.isPathUnderRoot
+import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
+import com.codescene.jetbrains.platform.util.Log
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.util.messages.MessageBusConnection
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class CodesceneRepoFilesListener(
+    private val project: Project,
+    private val gitRootPath: String,
+    private val observer: GitChangeObserverAdapter?,
+    private val mainLineBranchResolver: MainLineBranchResolver,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : Disposable {
+    private var connection: MessageBusConnection? = null
+    private var refreshJob: Job? = null
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    fun start() {
+        connection?.disconnect()
+        connection = project.messageBus.connect(this)
+        connection?.subscribe(
+            VirtualFileManager.VFS_CHANGES,
+            object : BulkFileListener {
+                override fun after(events: List<VFileEvent>) {
+                    var configChanged = false
+                    var rulesChanged = false
+                    for (event in events) {
+                        val path = event.path
+                        if (!isPathUnderRoot(path, gitRootPath)) continue
+                        if (isCodesceneConfigPath(path)) {
+                            configChanged = true
+                        } else if (isCodeHealthRulesPath(path)) {
+                            rulesChanged = true
+                        }
+                    }
+                    if (configChanged || rulesChanged) {
+                        scheduleRefresh(invalidateMainLineCache = configChanged)
+                    }
+                }
+            },
+        )
+    }
+
+    internal fun isCodesceneConfigPath(path: String): Boolean =
+        path.replace('\\', '/').lowercase().endsWith("/.codescene/config.json")
+
+    internal fun isCodeHealthRulesPath(path: String): Boolean =
+        path.replace('\\', '/').lowercase().endsWith("/.codescene/code-health-rules.json")
+
+    private fun scheduleRefresh(invalidateMainLineCache: Boolean) {
+        refreshJob?.cancel()
+        refreshJob =
+            scope.launch {
+                delay(DEBOUNCE_MS)
+                if (invalidateMainLineCache) {
+                    mainLineBranchResolver.invalidate(gitRootPath)
+                }
+                invalidateReviewCaches()
+                refreshReviews()
+            }
+    }
+
+    private fun invalidateReviewCaches() {
+        val serviceProvider = CodeSceneProjectServiceProvider.getInstance(project)
+        for ((path, _) in serviceProvider.deltaCacheService.getAll()) {
+            serviceProvider.deltaCacheService.invalidate(path)
+            serviceProvider.reviewCacheService.invalidate(path)
+            serviceProvider.baselineReviewCacheService.invalidate(path)
+        }
+    }
+
+    private suspend fun refreshReviews() {
+        val gitObserver = observer ?: return
+        gitObserver.repopulateFromRepoState()
+        val paths = (gitObserver.getChangedFilesVsBaseline() + gitObserver.getTrackedFiles()).distinct()
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) return@invokeLater
+            for (path in paths) {
+                scheduleGitChangeReview(project, path)
+            }
+            Log.info("Scheduled ${paths.size} reviews after .codescene file change", "CodesceneRepoFilesListener")
+        }
+    }
+
+    override fun dispose() {
+        connection?.disconnect()
+        connection = null
+        scope.cancel()
+    }
+
+    private companion object {
+        private const val DEBOUNCE_MS = 500L
+    }
+}

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt
@@ -3,7 +3,6 @@ package com.codescene.jetbrains.platform.git
 import com.codescene.jetbrains.core.contracts.IFileSystem
 import com.codescene.jetbrains.core.contracts.IGitChangeLister
 import com.codescene.jetbrains.core.git.FileSystemAdapter
-import com.codescene.jetbrains.core.git.MAIN_LINE_BRANCH_NAMES
 import com.codescene.jetbrains.core.git.MAX_UNTRACKED_FILES_PER_LOCATION
 import com.codescene.jetbrains.core.git.createWorkspacePrefix
 import com.codescene.jetbrains.core.git.pathComparisonKey
@@ -60,7 +59,11 @@ class Git4IdeaChangeLister
         val project: Project,
         private val fileSystem: IFileSystem = FileSystemAdapter(),
         private val gitExecutor: GitCommandExecutor = Git4IdeaCommandExecutor(project),
+        private val injectedMainLineBranchResolver: MainLineBranchResolver? = null,
     ) : IGitChangeLister {
+        private val mainLineBranchResolver: MainLineBranchResolver
+            get() = injectedMainLineBranchResolver ?: MainLineBranchResolver.getInstance(project)
+
         companion object {
             fun getInstance(project: Project): Git4IdeaChangeLister = project.service<Git4IdeaChangeLister>()
         }
@@ -243,23 +246,22 @@ class Git4IdeaChangeLister
 
         private fun getMergeBase(repository: GitRepository): String? {
             val currentBranch = repository.currentBranchName ?: return null
+            val mainLineContext = mainLineBranchResolver.contextFor(repository)
 
-            if (isMainLineBranch(currentBranch)) {
+            if (mainLineContext.isMainLineBranch(currentBranch)) {
                 Log.info("On mainline branch, using HEAD", "Git4IdeaChangeLister")
                 return resolveHeadCommitSha(repository)
             }
 
-            return findMergeBaseWithMain(repository, currentBranch)
+            return findMergeBaseWithMain(repository, currentBranch, mainLineContext.refsForMergeBaseProbe())
         }
-
-        private fun isMainLineBranch(branchName: String): Boolean =
-            MAIN_LINE_BRANCH_NAMES.any { it.equals(branchName, ignoreCase = true) }
 
         private fun resolveHeadCommitSha(repository: GitRepository): String? = gitExecutor.runRevParse(repository)
 
         private fun findMergeBaseWithMain(
             repository: GitRepository,
             currentBranchName: String,
+            refs: List<String>,
         ): String? {
             val resolved =
                 resolveClosestMainLineMergeBase(
@@ -269,6 +271,7 @@ class Git4IdeaChangeLister
                     mergeBaseForRef = { ref ->
                         gitExecutor.runMergeBase(repository, currentBranchName, ref)
                     },
+                    refs = refs,
                 )
             if (resolved != null) {
                 Log.info("Resolved closest main-line merge base", "Git4IdeaChangeLister")

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaCommandExecutor.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaCommandExecutor.kt
@@ -71,7 +71,10 @@ class Git4IdeaCommandExecutor(private val project: Project) : GitCommandExecutor
         val ref = result.output.first().trim()
         val originPrefix = "origin/"
         return when {
-            ref.startsWith(originPrefix) -> ref.removePrefix(originPrefix).takeIf { it.isNotEmpty() }
+            ref.startsWith(originPrefix) -> {
+                val stripped = ref.removePrefix(originPrefix)
+                stripped.takeIf { it.isNotEmpty() && it != "HEAD" }
+            }
             ref == "HEAD" || ref.isEmpty() -> null
             else -> ref
         }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaCommandExecutor.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaCommandExecutor.kt
@@ -60,4 +60,33 @@ class Git4IdeaCommandExecutor(private val project: Project) : GitCommandExecutor
             }
         return Git.getInstance().runCommand(handler).success()
     }
+
+    override fun resolveOriginHeadBranch(repository: GitRepository): String? {
+        val handler =
+            createGitLineHandler(project, repository.root, GitCommand.REV_PARSE).apply {
+                addParameters("--abbrev-ref", "refs/remotes/origin/HEAD")
+            }
+        val result = Git.getInstance().runCommand(handler)
+        if (!result.success() || result.output.isEmpty()) return null
+        val ref = result.output.first().trim()
+        val originPrefix = "origin/"
+        return when {
+            ref.startsWith(originPrefix) -> ref.removePrefix(originPrefix).takeIf { it.isNotEmpty() }
+            ref == "HEAD" || ref.isEmpty() -> null
+            else -> ref
+        }
+    }
+
+    override fun localBranchNames(repository: GitRepository): Set<String> {
+        val handler =
+            createGitLineHandler(project, repository.root, GitCommand.BRANCH).apply {
+                addParameters("--format=%(refname:short)")
+            }
+        val result = Git.getInstance().runCommand(handler)
+        if (!result.success()) return emptySet()
+        return result.output
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
+    }
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaGitService.kt
@@ -1,7 +1,6 @@
 package com.codescene.jetbrains.platform.git
 
 import com.codescene.jetbrains.core.contracts.IGitService
-import com.codescene.jetbrains.core.git.MAIN_LINE_BRANCH_NAMES
 import com.codescene.jetbrains.core.git.resolveClosestMainLineMergeBase
 import com.codescene.jetbrains.core.util.parseBranchCreationCommitFromReflog
 import com.codescene.jetbrains.platform.util.Log
@@ -19,173 +18,185 @@ import git4idea.repo.GitRepository
 import git4idea.repo.GitRepositoryManager
 
 @Service(Service.Level.PROJECT)
-class Git4IdeaGitService(val project: Project) : IGitService {
-    private val service = "${this::class.java.simpleName} - ${project.name}"
-    private val gitCommandExecutor = Git4IdeaCommandExecutor(project)
+class Git4IdeaGitService
+    @JvmOverloads
+    constructor(
+        val project: Project,
+        private val injectedMainLineBranchResolver: MainLineBranchResolver? = null,
+    ) : IGitService {
+        private val service = "${this::class.java.simpleName} - ${project.name}"
+        private val gitCommandExecutor = Git4IdeaCommandExecutor(project)
+        private val mainLineBranchResolver: MainLineBranchResolver
+            get() = injectedMainLineBranchResolver ?: MainLineBranchResolver.getInstance(project)
 
-    private data class RepositoryContext(
-        val file: VirtualFile,
-        val repository: GitRepository,
-        val relativePath: String,
-    )
-
-    companion object {
-        fun getInstance(project: Project): Git4IdeaGitService = project.service<Git4IdeaGitService>()
-    }
-
-    /**
-     * Resolves baseline file content for delta analysis, aligned with VS / VS Code:
-     * - On a main-line branch (main, master, develop, trunk, dev): **HEAD** commit.
-     * - On a feature branch: **closest merge-base** among all resolvable main-line refs (same probe order as VS Code).
-     * - Fallback: branch-creation commit from the current branch’s reflog (same as the previous JetBrains-only behavior).
-     */
-    override fun getBranchCreationCommitCode(filePath: String): String {
-        val file = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return ""
-        val context = getRepositoryContext(file) ?: return ""
-
-        if (context.repository.state == Repository.State.DETACHED) return ""
-
-        val commit =
-            getBaselineCommitSha(context.repository) ?: run {
-                Log.debug("Could not retrieve baseline commit for ${context.file.path}", service)
-                return ""
-            }
-
-        val handler =
-            createGitLineHandler(project, context.repository.root, GitCommand.SHOW).apply {
-                addParameters("$commit:${context.relativePath}")
-            }
-
-        return Git.getInstance().runCommand(handler).let {
-            if (it.success()) {
-                it.output.joinToString("\n").replace("\r\n", "\n").replace('\r', '\n')
-            } else {
-                ""
-            }
-        }
-    }
-
-    override fun getBranchCreationCommitHash(filePath: String): String? {
-        val file = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return null
-        val context = getRepositoryContext(file) ?: return null
-
-        if (context.repository.state == Repository.State.DETACHED) {
-            return null
-        }
-
-        return getBaselineCommitSha(context.repository)
-    }
-
-    override fun getRepoRelativePath(filePath: String): String? =
-        LocalFileSystem.getInstance()
-            .findFileByPath(filePath)
-            ?.let { file -> getRepositoryContext(file)?.relativePath }
-
-    override fun getRepoRoot(filePath: String): String? =
-        LocalFileSystem.getInstance()
-            .findFileByPath(filePath)
-            ?.let { file -> getRepositoryContext(file)?.repository?.root?.path }
-
-    override fun isIgnored(filePath: String): Boolean {
-        val file = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return false
-        val context = getRepositoryContext(file) ?: return false
-        return context.repository.ignoredFilesHolder.containsFile(VcsUtil.getFilePath(context.file))
-    }
-
-    private fun getBaselineCommitSha(gitRepository: GitRepository): String? {
-        val branchName = gitRepository.currentBranchName ?: return null
-
-        if (MAIN_LINE_BRANCH_NAMES.any { it.equals(branchName, ignoreCase = true) }) {
-            return resolveHeadCommitSha(gitRepository)
-        }
-
-        val mergeBase = findMergeBaseWithMain(gitRepository)
-        if (!mergeBase.isNullOrBlank()) {
-            return mergeBase.trim()
-        }
-
-        return getBranchCreationCommitFromReflog(gitRepository)
-    }
-
-    private fun resolveHeadCommitSha(gitRepository: GitRepository): String? {
-        val handler =
-            createGitLineHandler(project, gitRepository.root, GitCommand.REV_PARSE).apply {
-                addParameters("HEAD")
-            }
-        return Git.getInstance().runCommand(handler).let { result ->
-            if (result.success() && result.output.isNotEmpty()) {
-                result.output.first().trim()
-            } else {
-                null
-            }
-        }
-    }
-
-    private fun findMergeBaseWithMain(gitRepository: GitRepository): String? {
-        val currentBranchName = gitRepository.currentBranchName ?: return null
-        return resolveClosestMainLineMergeBase(
-            isAncestor = { ancestor, descendant ->
-                gitCommandExecutor.runIsAncestor(gitRepository, ancestor, descendant)
-            },
-            mergeBaseForRef = { ref ->
-                gitCommandExecutor.runMergeBase(gitRepository, currentBranchName, ref)
-            },
+        private data class RepositoryContext(
+            val file: VirtualFile,
+            val repository: GitRepository,
+            val relativePath: String,
         )
-    }
 
-    private fun getBranchCreationCommitFromReflog(gitRepository: GitRepository): String? =
-        getRefLog(project, gitRepository)?.let { parseBranchCreationCommitFromReflog(it) }
+        companion object {
+            fun getInstance(project: Project): Git4IdeaGitService = project.service<Git4IdeaGitService>()
+        }
 
-    private fun getRefLog(
-        project: Project,
-        gitRepository: GitRepository,
-    ): List<String>? {
-        val handler =
-            createGitLineHandler(project, gitRepository.root, GitCommand.REF_LOG).apply {
-                addParameters(gitRepository.currentBranchName!!)
-            }
+        /**
+         * Resolves baseline file content for delta analysis, aligned with VS / VS Code:
+         * - On the repository default / configured baseline branch: **HEAD** commit.
+         * - On a feature branch: **closest merge-base** among resolved main-line refs (config, origin/HEAD, then local static fallbacks).
+         * - Fallback: branch-creation commit from the current branch’s reflog (same as the previous JetBrains-only behavior).
+         */
+        override fun getBranchCreationCommitCode(filePath: String): String {
+            val file = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return ""
+            val context = getRepositoryContext(file) ?: return ""
 
-        return Git.getInstance().runCommand(handler).let {
-            if (it.success()) {
-                it.output
-            } else {
-                null
+            if (context.repository.state == Repository.State.DETACHED) return ""
+
+            val commit =
+                getBaselineCommitSha(context.repository) ?: run {
+                    Log.debug("Could not retrieve baseline commit for ${context.file.path}", service)
+                    return ""
+                }
+
+            val handler =
+                createGitLineHandler(project, context.repository.root, GitCommand.SHOW).apply {
+                    addParameters("$commit:${context.relativePath}")
+                }
+
+            return Git.getInstance().runCommand(handler).let {
+                if (it.success()) {
+                    it.output.joinToString("\n").replace("\r\n", "\n").replace('\r', '\n')
+                } else {
+                    ""
+                }
             }
         }
-    }
 
-    internal fun resolveRepository(file: VirtualFile): GitRepository? {
-        val manager = GitRepositoryManager.getInstance(project)
-        val vcsRoot = ProjectLevelVcsManager.getInstance(project).getVcsRootFor(file) ?: return null
-        return manager.getRepositoryForRootQuick(vcsRoot)
-            ?: findDeepestMatchingRepository(manager.repositories, file.path)
-    }
+        override fun getBranchCreationCommitHash(filePath: String): String? {
+            val file = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return null
+            val context = getRepositoryContext(file) ?: return null
 
-    private fun findDeepestMatchingRepository(
-        repositories: Collection<GitRepository>,
-        filePath: String,
-    ): GitRepository? =
-        repositories
-            .filter { repo ->
-                val rootPath = repo.root.path
-                filePath == rootPath || filePath.startsWith("$rootPath/")
-            }
-            .maxByOrNull { it.root.path.length }
-
-    private fun getRepositoryContext(file: VirtualFile): RepositoryContext? {
-        val repository =
-            resolveRepository(file) ?: run {
-                Log.debug("File ${file.path} is not part of a Git repository.", service)
+            if (context.repository.state == Repository.State.DETACHED) {
                 return null
             }
 
-        val repositoryRoot = repository.root.path
-        if (!file.path.startsWith("$repositoryRoot/")) {
-            Log.warn("File ${file.path} is not within the repository root $repositoryRoot.")
-            return null
+            return getBaselineCommitSha(context.repository)
         }
 
-        val relativePath = file.path.substringAfter("$repositoryRoot/")
-        return RepositoryContext(file, repository, relativePath)
+        override fun getRepoRelativePath(filePath: String): String? =
+            LocalFileSystem.getInstance()
+                .findFileByPath(filePath)
+                ?.let { file -> getRepositoryContext(file)?.relativePath }
+
+        override fun getRepoRoot(filePath: String): String? =
+            LocalFileSystem.getInstance()
+                .findFileByPath(filePath)
+                ?.let { file -> getRepositoryContext(file)?.repository?.root?.path }
+
+        override fun isIgnored(filePath: String): Boolean {
+            val file = LocalFileSystem.getInstance().findFileByPath(filePath) ?: return false
+            val context = getRepositoryContext(file) ?: return false
+            return context.repository.ignoredFilesHolder.containsFile(VcsUtil.getFilePath(context.file))
+        }
+
+        private fun getBaselineCommitSha(gitRepository: GitRepository): String? {
+            val branchName = gitRepository.currentBranchName ?: return null
+            val mainLineContext = mainLineBranchResolver.contextFor(gitRepository)
+
+            if (mainLineContext.isMainLineBranch(branchName)) {
+                return resolveHeadCommitSha(gitRepository)
+            }
+
+            val mergeBase = findMergeBaseWithMain(gitRepository, mainLineContext.refsForMergeBaseProbe())
+            if (!mergeBase.isNullOrBlank()) {
+                return mergeBase.trim()
+            }
+
+            return getBranchCreationCommitFromReflog(gitRepository)
+        }
+
+        private fun resolveHeadCommitSha(gitRepository: GitRepository): String? {
+            val handler =
+                createGitLineHandler(project, gitRepository.root, GitCommand.REV_PARSE).apply {
+                    addParameters("HEAD")
+                }
+            return Git.getInstance().runCommand(handler).let { result ->
+                if (result.success() && result.output.isNotEmpty()) {
+                    result.output.first().trim()
+                } else {
+                    null
+                }
+            }
+        }
+
+        private fun findMergeBaseWithMain(
+            gitRepository: GitRepository,
+            refs: List<String>,
+        ): String? {
+            val currentBranchName = gitRepository.currentBranchName ?: return null
+            return resolveClosestMainLineMergeBase(
+                isAncestor = { ancestor, descendant ->
+                    gitCommandExecutor.runIsAncestor(gitRepository, ancestor, descendant)
+                },
+                mergeBaseForRef = { ref ->
+                    gitCommandExecutor.runMergeBase(gitRepository, currentBranchName, ref)
+                },
+                refs = refs,
+            )
+        }
+
+        private fun getBranchCreationCommitFromReflog(gitRepository: GitRepository): String? =
+            getRefLog(project, gitRepository)?.let { parseBranchCreationCommitFromReflog(it) }
+
+        private fun getRefLog(
+            project: Project,
+            gitRepository: GitRepository,
+        ): List<String>? {
+            val handler =
+                createGitLineHandler(project, gitRepository.root, GitCommand.REF_LOG).apply {
+                    addParameters(gitRepository.currentBranchName!!)
+                }
+
+            return Git.getInstance().runCommand(handler).let {
+                if (it.success()) {
+                    it.output
+                } else {
+                    null
+                }
+            }
+        }
+
+        internal fun resolveRepository(file: VirtualFile): GitRepository? {
+            val manager = GitRepositoryManager.getInstance(project)
+            val vcsRoot = ProjectLevelVcsManager.getInstance(project).getVcsRootFor(file) ?: return null
+            return manager.getRepositoryForRootQuick(vcsRoot)
+                ?: findDeepestMatchingRepository(manager.repositories, file.path)
+        }
+
+        private fun findDeepestMatchingRepository(
+            repositories: Collection<GitRepository>,
+            filePath: String,
+        ): GitRepository? =
+            repositories
+                .filter { repo ->
+                    val rootPath = repo.root.path
+                    filePath == rootPath || filePath.startsWith("$rootPath/")
+                }
+                .maxByOrNull { it.root.path.length }
+
+        private fun getRepositoryContext(file: VirtualFile): RepositoryContext? {
+            val repository =
+                resolveRepository(file) ?: run {
+                    Log.debug("File ${file.path} is not part of a Git repository.", service)
+                    return null
+                }
+
+            val repositoryRoot = repository.root.path
+            if (!file.path.startsWith("$repositoryRoot/")) {
+                Log.warn("File ${file.path} is not within the repository root $repositoryRoot.")
+                return null
+            }
+
+            val relativePath = file.path.substringAfter("$repositoryRoot/")
+            return RepositoryContext(file, repository, relativePath)
+        }
     }
-}

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverAdapter.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverAdapter.kt
@@ -65,6 +65,8 @@ class GitChangeObserverAdapter(
 
     fun getQueuedEventCount(): Int = observer.getQueuedEventCount()
 
+    suspend fun repopulateFromRepoState() = observer.populateTrackerFromRepoState()
+
     override fun dispose() {
         Log.info("Disposing, cancelling scope", "GitChangeObserverAdapter")
         scope.cancel()

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverService.kt
@@ -53,6 +53,7 @@ class GitChangeObserverService(
     private var vfsEventBridge: VfsEventBridge? = null
     private var savedFilesTracker: SavedFilesTrackerAdapter? = null
     private var repoStateListener: GitRepoStateListener? = null
+    private var codesceneRepoFilesListener: CodesceneRepoFilesListener? = null
 
     fun start() {
         val workspacePath = project.basePath
@@ -107,8 +108,19 @@ class GitChangeObserverService(
         repoStateListener = listener
         Disposer.register(this, listener)
 
+        val repoFilesListener =
+            CodesceneRepoFilesListener(
+                project,
+                gitRootPath,
+                gitChangeObserver,
+                MainLineBranchResolver.getInstance(project),
+            )
+        codesceneRepoFilesListener = repoFilesListener
+        Disposer.register(this, repoFilesListener)
+
         bridge.start()
         listener.start()
+        repoFilesListener.start()
         gitChangeObserver.start()
     }
 
@@ -155,6 +167,7 @@ class GitChangeObserverService(
         savedFilesTracker = null
         vfsEventBridge = null
         repoStateListener = null
+        codesceneRepoFilesListener = null
         observer = null
     }
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitCommandExecutor.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitCommandExecutor.kt
@@ -21,4 +21,8 @@ interface GitCommandExecutor {
         ancestor: String,
         descendant: String,
     ): Boolean
+
+    fun resolveOriginHeadBranch(repository: GitRepository): String?
+
+    fun localBranchNames(repository: GitRepository): Set<String>
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/MainLineBranchResolver.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/MainLineBranchResolver.kt
@@ -1,0 +1,50 @@
+package com.codescene.jetbrains.platform.git
+
+import com.codescene.jetbrains.core.git.MainLineBranchContext
+import com.codescene.jetbrains.core.git.parseBaselineBranchFromConfig
+import com.codescene.jetbrains.core.git.pathComparisonKey
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import git4idea.repo.GitRepository
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.concurrent.ConcurrentHashMap
+
+@Service(Service.Level.PROJECT)
+class MainLineBranchResolver
+    @JvmOverloads
+    constructor(
+        private val project: Project,
+        private val gitExecutor: GitCommandExecutor = Git4IdeaCommandExecutor(project),
+    ) {
+        private val cache = ConcurrentHashMap<String, MainLineBranchContext>()
+
+        fun contextFor(repository: GitRepository): MainLineBranchContext {
+            val cacheKey = pathComparisonKey(repository.root.path)
+            return cache.getOrPut(cacheKey) { loadContext(repository) }
+        }
+
+        fun invalidate(gitRoot: String) {
+            cache.remove(pathComparisonKey(gitRoot))
+        }
+
+        private fun loadContext(repository: GitRepository): MainLineBranchContext {
+            val configPath = Paths.get(repository.root.path, ".codescene", "config.json")
+            val configText =
+                if (Files.isRegularFile(configPath)) {
+                    Files.readString(configPath)
+                } else {
+                    null
+                }
+            return MainLineBranchContext(
+                configuredBaseline = parseBaselineBranchFromConfig(configText),
+                defaultBranchFromOriginHead = gitExecutor.resolveOriginHeadBranch(repository),
+                localBranchNames = gitExecutor.localBranchNames(repository),
+            )
+        }
+
+        companion object {
+            fun getInstance(project: Project): MainLineBranchResolver = project.service<MainLineBranchResolver>()
+        }
+    }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/MainLineBranchResolver.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/MainLineBranchResolver.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import git4idea.repo.GitRepository
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.ConcurrentHashMap
@@ -22,7 +23,7 @@ class MainLineBranchResolver
 
         fun contextFor(repository: GitRepository): MainLineBranchContext {
             val cacheKey = pathComparisonKey(repository.root.path)
-            return cache.getOrPut(cacheKey) { loadContext(repository) }
+            return cache.computeIfAbsent(cacheKey) { loadContext(repository) }
         }
 
         fun invalidate(gitRoot: String) {
@@ -33,7 +34,11 @@ class MainLineBranchResolver
             val configPath = Paths.get(repository.root.path, ".codescene", "config.json")
             val configText =
                 if (Files.isRegularFile(configPath)) {
-                    Files.readString(configPath)
+                    try {
+                        Files.readString(configPath)
+                    } catch (_: IOException) {
+                        null
+                    }
                 } else {
                     null
                 }

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/CodesceneRepoFilesListenerTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/CodesceneRepoFilesListenerTest.kt
@@ -1,0 +1,28 @@
+package com.codescene.jetbrains.platform.git
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CodesceneRepoFilesListenerTest {
+    private val listener =
+        CodesceneRepoFilesListener(
+            project = io.mockk.mockk(relaxed = true),
+            gitRootPath = "/repo",
+            observer = null,
+            mainLineBranchResolver = io.mockk.mockk(relaxed = true),
+        )
+
+    @Test
+    fun `isCodesceneConfigPath matches config json under codescene`() {
+        assertTrue(listener.isCodesceneConfigPath("/repo/.codescene/config.json"))
+        assertTrue(listener.isCodesceneConfigPath("C:\\repo\\.codescene\\config.json"))
+        assertFalse(listener.isCodesceneConfigPath("/repo/.codescene/code-health-rules.json"))
+    }
+
+    @Test
+    fun `isCodeHealthRulesPath matches rules json`() {
+        assertTrue(listener.isCodeHealthRulesPath("/repo/.codescene/code-health-rules.json"))
+        assertFalse(listener.isCodeHealthRulesPath("/repo/.codescene/config.json"))
+    }
+}

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerFeatureBranchTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerFeatureBranchTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 
 class Git4IdeaChangeListerFeatureBranchTest : Git4IdeaChangeListerTestFixture() {
     @Test
-    fun `getAllChangedFiles uses closest merge base when main and develop disagree`() =
+    fun `getAllChangedFiles uses origin default merge base only when main and develop exist`() =
         runBlocking {
             val workspace = "/test/repo"
             val branch = "feature-stacked"
@@ -27,19 +27,21 @@ class Git4IdeaChangeListerFeatureBranchTest : Git4IdeaChangeListerTestFixture() 
             Git4IdeaTestSupport.setupEmptyUntrackedFiles(mockRepository)
             every { mockRepository.currentBranchName } returns branch
             every { mockRepository.root } returns mockVirtualFile
+            stubMainLineContext(
+                defaultBranchFromOriginHead = "main",
+                localBranchNames = setOf("main", "develop"),
+            )
 
             every { mockGitExecutor.runMergeBase(mockRepository, branch, "main") } returns "oldMainMb"
-            every { mockGitExecutor.runMergeBase(mockRepository, branch, "develop") } returns "developMb"
-            every { mockGitExecutor.runIsAncestor(mockRepository, "oldMainMb", "developMb") } returns true
-            every { mockGitExecutor.runIsAncestor(mockRepository, "developMb", "oldMainMb") } returns false
-
-            every { mockGitExecutor.runDiff(mockRepository, "developMb") } returns listOf("stacked.ts")
+            every { mockGitExecutor.runMergeBase(mockRepository, branch, "origin/main") } returns "oldMainMb"
+            every { mockGitExecutor.runDiff(mockRepository, "oldMainMb") } returns listOf("stacked.ts")
 
             Git4IdeaTestSupport.setupFileSystemForFile(mockFileSystem, gitRoot, workspace, "stacked.ts", "ts")
 
             git4IdeaChangeLister.getAllChangedFiles(gitRoot, workspace)
 
-            verify(exactly = 1) { mockGitExecutor.runDiff(mockRepository, "developMb") }
+            verify(exactly = 1) { mockGitExecutor.runDiff(mockRepository, "oldMainMb") }
+            verify(exactly = 0) { mockGitExecutor.runMergeBase(mockRepository, branch, "develop") }
         }
 
     @Test
@@ -116,6 +118,7 @@ class Git4IdeaChangeListerFeatureBranchTest : Git4IdeaChangeListerTestFixture() 
             Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
             every { mockRepository.currentBranchName } returns "master"
             every { mockGitExecutor.runRevParse(mockRepository) } returns "abc123"
+            stubMainLineContext(localBranchNames = setOf("master"))
 
             val files =
                 (1..10).map { i ->
@@ -160,6 +163,7 @@ class Git4IdeaChangeListerFeatureBranchTest : Git4IdeaChangeListerTestFixture() 
             Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
             every { mockRepository.currentBranchName } returns "master"
             every { mockGitExecutor.runRevParse(mockRepository) } returns "abc123"
+            stubMainLineContext(localBranchNames = setOf("master"))
 
             val untrackedFile = mockk<com.intellij.openapi.vcs.FilePath>()
             every { untrackedFile.path } returns "$gitRoot/test.ts"

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerTest.kt
@@ -31,6 +31,7 @@ class Git4IdeaChangeListerTest : Git4IdeaChangeListerTestFixture() {
                 "/test/repo",
             )
             Git4IdeaTestSupport.setupCleanRepository(mockRepository, mockStagingArea, mockGitExecutor)
+            stubMainLineContext(localBranchNames = setOf("master"))
 
             val changedFiles = git4IdeaChangeLister.getAllChangedFiles("/test/repo", "/test/repo")
 
@@ -50,6 +51,7 @@ class Git4IdeaChangeListerTest : Git4IdeaChangeListerTestFixture() {
             Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
             every { mockRepository.currentBranchName } returns "master"
             every { mockGitExecutor.runRevParse(mockRepository) } returns "abc123"
+            stubMainLineContext(localBranchNames = setOf("master"))
 
             val untrackedFile = mockk<com.intellij.openapi.vcs.FilePath>()
             every { untrackedFile.path } returns "test.ts"
@@ -76,6 +78,7 @@ class Git4IdeaChangeListerTest : Git4IdeaChangeListerTestFixture() {
             Git4IdeaTestSupport.setupEmptyUntrackedFiles(mockRepository)
             every { mockRepository.currentBranchName } returns "master"
             every { mockGitExecutor.runRevParse(mockRepository) } returns "abc123"
+            stubMainLineContext(localBranchNames = setOf("master"))
 
             val mockFilePath = mockk<com.intellij.openapi.vcs.FilePath>()
             every { mockFilePath.path } returns "index.js"
@@ -109,6 +112,7 @@ class Git4IdeaChangeListerTest : Git4IdeaChangeListerTestFixture() {
             Git4IdeaTestSupport.setupEmptyStagingArea(mockRepository, mockStagingArea)
             every { mockRepository.currentBranchName } returns "master"
             every { mockGitExecutor.runRevParse(mockRepository) } returns "abc123"
+            stubMainLineContext(localBranchNames = setOf("master"))
 
             val txtFile = mockk<com.intellij.openapi.vcs.FilePath>()
             every { txtFile.path } returns "notes.txt"

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerTestFixture.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerTestFixture.kt
@@ -1,6 +1,7 @@
 package com.codescene.jetbrains.platform.git
 
 import com.codescene.jetbrains.core.contracts.IFileSystem
+import com.codescene.jetbrains.core.git.MainLineBranchContext
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
@@ -26,6 +27,7 @@ abstract class Git4IdeaChangeListerTestFixture {
     protected lateinit var mockStagingArea: GitStagingAreaHolder
     protected lateinit var mockFileSystem: IFileSystem
     protected lateinit var mockGitExecutor: GitCommandExecutor
+    protected lateinit var mockMainLineBranchResolver: MainLineBranchResolver
     protected lateinit var mockIgnoredFilesHolder: GitRepositoryIgnoredFilesHolder
 
     @Before
@@ -38,6 +40,7 @@ abstract class Git4IdeaChangeListerTestFixture {
         mockStagingArea = mockk(relaxed = true)
         mockFileSystem = mockk(relaxed = true)
         mockGitExecutor = mockk(relaxed = true)
+        mockMainLineBranchResolver = mockk(relaxed = true)
         mockIgnoredFilesHolder = mockk(relaxed = true)
 
         every { mockRepository.ignoredFilesHolder } returns mockIgnoredFilesHolder
@@ -49,7 +52,28 @@ abstract class Git4IdeaChangeListerTestFixture {
         mockkStatic(LocalFileSystem::class)
         every { LocalFileSystem.getInstance() } returns mockLocalFileSystem
 
-        git4IdeaChangeLister = Git4IdeaChangeLister(project, mockFileSystem, mockGitExecutor)
+        stubMainLineContext(defaultBranchFromOriginHead = "main", localBranchNames = setOf("main"))
+
+        git4IdeaChangeLister =
+            Git4IdeaChangeLister(
+                project,
+                mockFileSystem,
+                mockGitExecutor,
+                mockMainLineBranchResolver,
+            )
+    }
+
+    protected fun stubMainLineContext(
+        configuredBaseline: String? = null,
+        defaultBranchFromOriginHead: String? = null,
+        localBranchNames: Set<String> = emptySet(),
+    ) {
+        every { mockMainLineBranchResolver.contextFor(mockRepository) } returns
+            MainLineBranchContext(
+                configuredBaseline = configuredBaseline,
+                defaultBranchFromOriginHead = defaultBranchFromOriginHead,
+                localBranchNames = localBranchNames,
+            )
     }
 
     @After

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerWindowsPathTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeListerWindowsPathTest.kt
@@ -1,6 +1,7 @@
 package com.codescene.jetbrains.platform.git
 
 import com.codescene.jetbrains.core.contracts.IFileSystem
+import com.codescene.jetbrains.core.git.MainLineBranchContext
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
@@ -29,6 +30,7 @@ class Git4IdeaChangeListerWindowsPathTest {
     private lateinit var mockStagingArea: GitStagingAreaHolder
     private lateinit var mockFileSystem: IFileSystem
     private lateinit var mockGitExecutor: GitCommandExecutor
+    private lateinit var mockMainLineBranchResolver: MainLineBranchResolver
     private lateinit var mockIgnoredFilesHolder: GitRepositoryIgnoredFilesHolder
 
     @Before
@@ -41,6 +43,7 @@ class Git4IdeaChangeListerWindowsPathTest {
         mockStagingArea = mockk(relaxed = true)
         mockFileSystem = mockk(relaxed = true)
         mockGitExecutor = mockk(relaxed = true)
+        mockMainLineBranchResolver = mockk(relaxed = true)
         mockIgnoredFilesHolder = mockk(relaxed = true)
 
         every { mockRepository.ignoredFilesHolder } returns mockIgnoredFilesHolder
@@ -52,7 +55,10 @@ class Git4IdeaChangeListerWindowsPathTest {
         mockkStatic(LocalFileSystem::class)
         every { LocalFileSystem.getInstance() } returns mockLocalFileSystem
 
-        git4IdeaChangeLister = Git4IdeaChangeLister(project, mockFileSystem, mockGitExecutor)
+        every { mockMainLineBranchResolver.contextFor(mockRepository) } returns
+            MainLineBranchContext(defaultBranchFromOriginHead = "main", localBranchNames = setOf("main"))
+        git4IdeaChangeLister =
+            Git4IdeaChangeLister(project, mockFileSystem, mockGitExecutor, mockMainLineBranchResolver)
     }
 
     @After

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/MainLineBranchResolverTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/MainLineBranchResolverTest.kt
@@ -1,0 +1,78 @@
+package com.codescene.jetbrains.platform.git
+
+import git4idea.repo.GitRepository
+import io.mockk.every
+import io.mockk.mockk
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MainLineBranchResolverTest {
+    @Test
+    fun `contextFor reads baseline_branch from config file`() {
+        val tempDir = Files.createTempDirectory("cs-config-test")
+        val codesceneDir = tempDir.resolve(".codescene")
+        Files.createDirectories(codesceneDir)
+        Files.writeString(codesceneDir.resolve("config.json"), """{"baseline_branch":"develop"}""")
+
+        val project = mockk<com.intellij.openapi.project.Project>(relaxed = true)
+        val repository = mockk<GitRepository>(relaxed = true)
+        val root = mockk<com.intellij.openapi.vfs.VirtualFile>(relaxed = true)
+        every { repository.root } returns root
+        every { root.path } returns tempDir.toString()
+
+        val gitExecutor = mockk<GitCommandExecutor>(relaxed = true)
+        every { gitExecutor.resolveOriginHeadBranch(repository) } returns "main"
+        every { gitExecutor.localBranchNames(repository) } returns setOf("main", "develop")
+
+        val resolver = MainLineBranchResolver(project, gitExecutor)
+        val context = resolver.contextFor(repository)
+
+        assertEquals("develop", context.configuredBaseline)
+        assertEquals(listOf("develop", "origin/develop"), context.refsForMergeBaseProbe())
+    }
+
+    @Test
+    fun `contextFor uses origin HEAD when config missing`() {
+        val tempDir = Files.createTempDirectory("cs-origin-test")
+
+        val project = mockk<com.intellij.openapi.project.Project>(relaxed = true)
+        val repository = mockk<GitRepository>(relaxed = true)
+        val root = mockk<com.intellij.openapi.vfs.VirtualFile>(relaxed = true)
+        every { repository.root } returns root
+        every { root.path } returns tempDir.toString()
+
+        val gitExecutor = mockk<GitCommandExecutor>(relaxed = true)
+        every { gitExecutor.resolveOriginHeadBranch(repository) } returns "main"
+        every { gitExecutor.localBranchNames(repository) } returns setOf("main", "master")
+
+        val resolver = MainLineBranchResolver(project, gitExecutor)
+        val context = resolver.contextFor(repository)
+
+        assertEquals("main", context.defaultBranchFromOriginHead)
+        assertTrue(context.isMainLineBranch("main"))
+        assertEquals(false, context.isMainLineBranch("master"))
+    }
+
+    @Test
+    fun `invalidate forces reload`() {
+        val tempDir = Files.createTempDirectory("cs-invalidate-test")
+
+        val project = mockk<com.intellij.openapi.project.Project>(relaxed = true)
+        val repository = mockk<GitRepository>(relaxed = true)
+        val root = mockk<com.intellij.openapi.vfs.VirtualFile>(relaxed = true)
+        every { repository.root } returns root
+        every { root.path } returns tempDir.toString()
+
+        val gitExecutor = mockk<GitCommandExecutor>(relaxed = true)
+        every { gitExecutor.resolveOriginHeadBranch(repository) } returnsMany listOf("main", "develop")
+        every { gitExecutor.localBranchNames(repository) } returns setOf("main", "develop")
+
+        val resolver = MainLineBranchResolver(project, gitExecutor)
+        assertEquals("main", resolver.contextFor(repository).defaultBranchFromOriginHead)
+
+        resolver.invalidate(tempDir.toString())
+        assertEquals("develop", resolver.contextFor(repository).defaultBranchFromOriginHead)
+    }
+}


### PR DESCRIPTION
## Summary
- Resolve the delta baseline branch from `.codescene/config.json` (`baseline_branch`), then `origin/HEAD`, then a static list filtered to local branches
- Treat only the resolved default as main for HEAD baseline and merge-base probing (aligned with VS PR #279)
- Watch `.codescene/config.json` and `code-health-rules.json` for cache invalidation and review refresh

## Test plan
- [x] Core and platform git unit tests
- [x] ktlint
- [x] CodeScene MCP change-set / pre-commit checks
- [x] Manual: feature branch on repo with `origin/HEAD` → `main` and local `develop` uses `main` merge-base only
- [x] Manual: `baseline_branch` in config overrides default without restart
- [x] Manual: editing config while IDE open refreshes reviews