### PR TITLE
feat: Watch .gitignore changes and refresh analysis caches (CS-11313)

### DIFF
--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverService.kt
@@ -54,6 +54,7 @@ class GitChangeObserverService(
     private var savedFilesTracker: SavedFilesTrackerAdapter? = null
     private var repoStateListener: GitRepoStateListener? = null
     private var codesceneRepoFilesListener: CodesceneRepoFilesListener? = null
+    private var gitIgnoreFilesListener: GitIgnoreFilesListener? = null
 
     fun start() {
         val workspacePath = project.basePath
@@ -118,9 +119,19 @@ class GitChangeObserverService(
         codesceneRepoFilesListener = repoFilesListener
         Disposer.register(this, repoFilesListener)
 
+        val gitIgnoreListener =
+            GitIgnoreFilesListener(
+                project,
+                gitRootPath,
+                gitChangeObserver,
+            )
+        gitIgnoreFilesListener = gitIgnoreListener
+        Disposer.register(this, gitIgnoreListener)
+
         bridge.start()
         listener.start()
         repoFilesListener.start()
+        gitIgnoreListener.start()
         gitChangeObserver.start()
     }
 
@@ -168,6 +179,7 @@ class GitChangeObserverService(
         vfsEventBridge = null
         repoStateListener = null
         codesceneRepoFilesListener = null
+        gitIgnoreFilesListener = null
         observer = null
     }
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitIgnoreFilesListener.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitIgnoreFilesListener.kt
@@ -1,0 +1,98 @@
+package com.codescene.jetbrains.platform.git
+
+import com.codescene.jetbrains.core.git.isPathUnderRoot
+import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
+import com.codescene.jetbrains.platform.util.Log
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.util.messages.MessageBusConnection
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class GitIgnoreFilesListener(
+    private val project: Project,
+    private val gitRootPath: String,
+    private val observer: GitChangeObserverAdapter?,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : Disposable {
+    private var connection: MessageBusConnection? = null
+    private var refreshJob: Job? = null
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    fun start() {
+        connection?.disconnect()
+        connection = project.messageBus.connect(this)
+        connection?.subscribe(
+            VirtualFileManager.VFS_CHANGES,
+            object : BulkFileListener {
+                override fun after(events: List<VFileEvent>) {
+                    var gitIgnoreChanged = false
+                    for (event in events) {
+                        val path = event.path
+                        if (!isPathUnderRoot(path, gitRootPath)) continue
+                        if (isGitIgnorePath(path)) {
+                            gitIgnoreChanged = true
+                        }
+                    }
+                    if (gitIgnoreChanged) {
+                        scheduleRefresh()
+                    }
+                }
+            },
+        )
+    }
+
+    internal fun isGitIgnorePath(path: String): Boolean = path.replace('\\', '/').lowercase().endsWith("/.gitignore")
+
+    private fun scheduleRefresh() {
+        refreshJob?.cancel()
+        refreshJob =
+            scope.launch {
+                delay(DEBOUNCE_MS)
+                invalidateReviewCaches()
+                refreshReviews()
+            }
+    }
+
+    private fun invalidateReviewCaches() {
+        val serviceProvider = CodeSceneProjectServiceProvider.getInstance(project)
+        for ((path, _) in serviceProvider.deltaCacheService.getAll()) {
+            serviceProvider.deltaCacheService.invalidate(path)
+            serviceProvider.reviewCacheService.invalidate(path)
+            serviceProvider.baselineReviewCacheService.invalidate(path)
+        }
+    }
+
+    private suspend fun refreshReviews() {
+        val gitObserver = observer ?: return
+        gitObserver.repopulateFromRepoState()
+        val paths = (gitObserver.getChangedFilesVsBaseline() + gitObserver.getTrackedFiles()).distinct()
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) return@invokeLater
+            for (path in paths) {
+                scheduleGitChangeReview(project, path)
+            }
+            Log.info("Scheduled ${paths.size} reviews after .gitignore change", "GitIgnoreFilesListener")
+        }
+    }
+
+    override fun dispose() {
+        connection?.disconnect()
+        connection = null
+        scope.cancel()
+    }
+
+    private companion object {
+        private const val DEBOUNCE_MS = 500L
+    }
+}

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/GitIgnoreFilesListenerTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/GitIgnoreFilesListenerTest.kt
@@ -1,0 +1,32 @@
+package com.codescene.jetbrains.platform.git
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GitIgnoreFilesListenerTest {
+    private val listener =
+        GitIgnoreFilesListener(
+            project = io.mockk.mockk(relaxed = true),
+            gitRootPath = "/repo",
+            observer = null,
+        )
+
+    @Test
+    fun `isGitIgnorePath matches root gitignore`() {
+        assertTrue(listener.isGitIgnorePath("/repo/.gitignore"))
+        assertTrue(listener.isGitIgnorePath("C:\\repo\\.gitignore"))
+    }
+
+    @Test
+    fun `isGitIgnorePath matches nested gitignore`() {
+        assertTrue(listener.isGitIgnorePath("/repo/src/.gitignore"))
+    }
+
+    @Test
+    fun `isGitIgnorePath rejects non-gitignore paths`() {
+        assertFalse(listener.isGitIgnorePath("/repo/.codescene/config.json"))
+        assertFalse(listener.isGitIgnorePath("/repo/.git/info/exclude"))
+        assertFalse(listener.isGitIgnorePath("/repo/src/Foo.kt"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GitIgnoreFilesListener` next to `CodesceneRepoFilesListener` to detect `.gitignore` create/change/delete under the git root (including nested paths).
- On change: debounce, invalidate delta/review/baseline caches, repopulate the git change tracker, and re-schedule reviews for changed and tracked files (same pipeline as `code-health-rules.json`).
- Wire the listener in `GitChangeObserverService` with the same register/start/dispose pattern as the existing repo files listener.

## Test plan
- [x] `GitIgnoreFilesListenerTest` (path matching for root, nested, Windows paths)
- [x] ktlint format/check
- [x] CodeScene pre-commit safeguard passed
- [ ] Manual: edit `.gitignore` in a project with active analysis; confirm caches refresh and files re-review without IDE restart