### PR TITLE
Hide ACE unless fully enabled

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/models/settings/CodeSceneGlobalSettings.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/models/settings/CodeSceneGlobalSettings.kt
@@ -27,7 +27,7 @@ data class CodeSceneGlobalSettings(
     var telemetryNoticeShown: Boolean = false,
     var aceStatus: AceStatus = AceStatus.DEACTIVATED,
     var enableCodeLenses: Boolean = true,
-    var enableAutoRefactor: Boolean = true,
+    var enableAutoRefactor: Boolean = false,
     var aceTokenConfigured: Boolean = false,
     // This is a freemium flag for the Code Health Monitor. If a proper CHM feature flag becomes necessary, use the same approach as ACE and CWF. If not,
     // TODO delete this after the integration with core is complete.

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/models/shared/AutoRefactorConfig.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/models/shared/AutoRefactorConfig.kt
@@ -10,5 +10,5 @@ data class AutoRefactorConfig(
     val visible: Boolean = false,
     // Disable the visible button if visible: true
     val disabled: Boolean = true,
-    val aceStatus: AceStatusType = AceStatusType(status = "disabled", hasToken = false),
+    val aceStatus: AceStatusType? = AceStatusType(status = "disabled", hasToken = false),
 )

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/util/AutoRefactorConfigUtils.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/util/AutoRefactorConfigUtils.kt
@@ -13,18 +13,29 @@ fun mapAceStatusToCwfString(status: AceStatus): String =
         AceStatus.OFFLINE -> "offline"
     }
 
+fun shouldShowAceStatusIndicator(settings: CodeSceneGlobalSettings): Boolean =
+    settings.enableAutoRefactor &&
+        settings.aceTokenConfigured &&
+        settings.aceStatus != AceStatus.DEACTIVATED
+
 fun toAutoRefactorConfig(settings: CodeSceneGlobalSettings): AutoRefactorConfig {
     val hasToken = settings.aceTokenConfigured
     val isActivated = !(!settings.aceAcknowledged && hasToken)
+    val showIndicator = shouldShowAceStatusIndicator(settings)
     return AutoRefactorConfig(
         activated = isActivated,
-        visible = settings.enableAutoRefactor,
+        visible = showIndicator,
         disabled = !hasToken,
+        // Setting aceStatus to null hides the ACE status indicator in the CWF header
         aceStatus =
-            AceStatusType(
-                status = mapAceStatusToCwfString(settings.aceStatus),
-                hasToken = hasToken,
-            ),
+            if (showIndicator) {
+                AceStatusType(
+                    status = mapAceStatusToCwfString(settings.aceStatus),
+                    hasToken = hasToken,
+                )
+            } else {
+                null
+            },
     )
 }
 

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/util/SettingsChangeAction.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/util/SettingsChangeAction.kt
@@ -9,6 +9,8 @@ sealed class SettingsChangeAction {
     data class RefreshAceUI(val enabled: Boolean) : SettingsChangeAction()
 
     object PublishAceStatusChange : SettingsChangeAction()
+
+    object RefreshAceStatusBarWidget : SettingsChangeAction()
 }
 
 fun resolveSettingsChangeActions(
@@ -29,10 +31,12 @@ fun resolveSettingsChangeActions(
 
     if (oldState.enableAutoRefactor != newState.enableAutoRefactor) {
         actions.add(SettingsChangeAction.RefreshAceUI(newState.enableAutoRefactor))
+        actions.add(SettingsChangeAction.RefreshAceStatusBarWidget)
     }
 
     if (oldState.aceTokenConfigured != newState.aceTokenConfigured || aceAuthTokenChanged) {
         actions.add(SettingsChangeAction.RefreshAceUI(true))
+        actions.add(SettingsChangeAction.RefreshAceStatusBarWidget)
     }
 
     return actions

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/settings/SettingsStateManagerTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/settings/SettingsStateManagerTest.kt
@@ -29,7 +29,7 @@ class SettingsStateManagerTest {
         val s = fresh.getState()
         assertEquals(CODESCENE_SERVER_URL, s.serverUrl)
         assertTrue(s.enableCodeLenses)
-        assertTrue(s.enableAutoRefactor)
+        assertFalse(s.enableAutoRefactor)
         assertFalse(s.previewCodeHealthGate)
         assertTrue(s.telemetryConsentGiven)
         assertFalse(s.telemetryNoticeShown)

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/util/AutoRefactorConfigUtilsTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/util/AutoRefactorConfigUtilsTest.kt
@@ -4,6 +4,7 @@ import com.codescene.jetbrains.core.models.settings.AceStatus
 import com.codescene.jetbrains.core.models.settings.CodeSceneGlobalSettings
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -42,12 +43,49 @@ class AutoRefactorConfigUtilsTest {
     }
 
     @Test
-    fun `toAutoRefactorConfig visible follows enableAutoRefactor`() {
-        val enabled = toAutoRefactorConfig(CodeSceneGlobalSettings(enableAutoRefactor = true))
+    fun `toAutoRefactorConfig visible requires enableAutoRefactor and aceTokenConfigured`() {
+        val enabled =
+            toAutoRefactorConfig(
+                CodeSceneGlobalSettings(
+                    enableAutoRefactor = true,
+                    aceTokenConfigured = true,
+                    aceStatus = AceStatus.SIGNED_IN,
+                ),
+            )
         assertEquals(true, enabled.visible)
 
-        val disabled = toAutoRefactorConfig(CodeSceneGlobalSettings(enableAutoRefactor = false))
-        assertEquals(false, disabled.visible)
+        val disabledNoToken =
+            toAutoRefactorConfig(
+                CodeSceneGlobalSettings(
+                    enableAutoRefactor = true,
+                    aceTokenConfigured = false,
+                    aceStatus = AceStatus.SIGNED_IN,
+                ),
+            )
+        assertEquals(false, disabledNoToken.visible)
+
+        val disabledSetting =
+            toAutoRefactorConfig(
+                CodeSceneGlobalSettings(
+                    enableAutoRefactor = false,
+                    aceTokenConfigured = true,
+                    aceStatus = AceStatus.SIGNED_IN,
+                ),
+            )
+        assertEquals(false, disabledSetting.visible)
+    }
+
+    @Test
+    fun `toAutoRefactorConfig visible false when aceStatus is DEACTIVATED`() {
+        val result =
+            toAutoRefactorConfig(
+                CodeSceneGlobalSettings(
+                    enableAutoRefactor = true,
+                    aceTokenConfigured = true,
+                    aceStatus = AceStatus.DEACTIVATED,
+                ),
+            )
+        assertEquals(false, result.visible)
     }
 
     @Test
@@ -79,33 +117,34 @@ class AutoRefactorConfigUtilsTest {
     }
 
     @Test
-    fun `toAutoRefactorConfig aceStatus hasToken true when token present`() {
+    fun `toAutoRefactorConfig aceStatus present when indicator should show`() {
         val result =
             toAutoRefactorConfig(
                 CodeSceneGlobalSettings(
                     aceStatus = AceStatus.SIGNED_IN,
                     aceTokenConfigured = true,
+                    enableAutoRefactor = true,
                 ),
             )
-        assertTrue(result.aceStatus.hasToken)
-        assertEquals("enabled", result.aceStatus.status)
+        assertTrue(result.aceStatus!!.hasToken)
+        assertEquals("enabled", result.aceStatus!!.status)
     }
 
     @Test
-    fun `toAutoRefactorConfig aceStatus hasToken false when token blank`() {
+    fun `toAutoRefactorConfig aceStatus null when token missing`() {
         val result =
             toAutoRefactorConfig(
                 CodeSceneGlobalSettings(
                     aceStatus = AceStatus.SIGNED_OUT,
                     aceTokenConfigured = false,
+                    enableAutoRefactor = true,
                 ),
             )
-        assertFalse(result.aceStatus.hasToken)
-        assertEquals("enabled", result.aceStatus.status)
+        assertNull(result.aceStatus)
     }
 
     @Test
-    fun `toAutoRefactorConfig aceStatus reflects deactivated`() {
+    fun `toAutoRefactorConfig aceStatus is null when deactivated`() {
         val result =
             toAutoRefactorConfig(
                 CodeSceneGlobalSettings(
@@ -113,7 +152,7 @@ class AutoRefactorConfigUtilsTest {
                     aceTokenConfigured = true,
                 ),
             )
-        assertEquals("disabled", result.aceStatus.status)
+        assertNull(result.aceStatus)
     }
 
     @Test

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/util/SettingsChangeActionTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/util/SettingsChangeActionTest.kt
@@ -35,7 +35,13 @@ class SettingsChangeActionTest {
 
         val result = resolveSettingsChangeActions(oldState, newState)
 
-        assertEquals(listOf(SettingsChangeAction.RefreshAceUI(false)), result)
+        assertEquals(
+            listOf(
+                SettingsChangeAction.RefreshAceUI(false),
+                SettingsChangeAction.RefreshAceStatusBarWidget,
+            ),
+            result,
+        )
     }
 
     @Test
@@ -45,7 +51,13 @@ class SettingsChangeActionTest {
 
         val result = resolveSettingsChangeActions(oldState, newState)
 
-        assertEquals(listOf(SettingsChangeAction.RefreshAceUI(true)), result)
+        assertEquals(
+            listOf(
+                SettingsChangeAction.RefreshAceUI(true),
+                SettingsChangeAction.RefreshAceStatusBarWidget,
+            ),
+            result,
+        )
     }
 
     @Test
@@ -53,7 +65,13 @@ class SettingsChangeActionTest {
         val state = CodeSceneGlobalSettings(aceTokenConfigured = true)
         val result = resolveSettingsChangeActions(state, state, aceAuthTokenChanged = true)
 
-        assertEquals(listOf(SettingsChangeAction.RefreshAceUI(true)), result)
+        assertEquals(
+            listOf(
+                SettingsChangeAction.RefreshAceUI(true),
+                SettingsChangeAction.RefreshAceStatusBarWidget,
+            ),
+            result,
+        )
     }
 
     @Test
@@ -80,7 +98,9 @@ class SettingsChangeActionTest {
                 SettingsChangeAction.RefreshAceUI(true),
                 SettingsChangeAction.PublishAceStatusChange,
                 SettingsChangeAction.RefreshAceUI(false),
+                SettingsChangeAction.RefreshAceStatusBarWidget,
                 SettingsChangeAction.RefreshAceUI(true),
+                SettingsChangeAction.RefreshAceStatusBarWidget,
             ),
             result,
         )

--- a/src/main/kotlin/com/codescene/jetbrains/platform/listeners/ProjectStartupActivity.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/listeners/ProjectStartupActivity.kt
@@ -10,6 +10,7 @@ import com.codescene.jetbrains.platform.editor.codeVision.CodeSceneCodeVisionPro
 import com.codescene.jetbrains.platform.git.GitChangeObserverService
 import com.codescene.jetbrains.platform.git.PeriodicChangeListerService
 import com.codescene.jetbrains.platform.settings.CodeSceneGlobalSettingsStore
+import com.codescene.jetbrains.platform.statusbar.AceStatusBarWidgetFactory
 import com.codescene.jetbrains.platform.telemetry.TelemetryService
 import com.codescene.jetbrains.platform.telemetry.installGlobalUncaughtErrorTelemetry
 import com.codescene.jetbrains.platform.util.Log
@@ -27,6 +28,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.wm.impl.status.widget.StatusBarWidgetsManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -91,6 +93,9 @@ class ProjectStartupActivity : ProjectActivity {
                                 .messageBus
                                 .syncPublisher(AceStatusRefreshNotifier.TOPIC)
                                 .refresh()
+                        is SettingsChangeAction.RefreshAceStatusBarWidget ->
+                            project.service<StatusBarWidgetsManager>()
+                                .updateWidget(AceStatusBarWidgetFactory::class.java)
                     }
                 }
             }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/settings/CodeSceneGlobalSettingsStore.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/settings/CodeSceneGlobalSettingsStore.kt
@@ -27,7 +27,13 @@ class CodeSceneGlobalSettingsStore : PersistentStateComponent<CodeSceneGlobalSet
     override fun loadState(state: CodeSceneGlobalSettingsPersisted) {
         val legacyToken = state.aceAuthToken.takeIf { it.isNotBlank() }
         val tokenConfigured = state.aceTokenConfigured || legacyToken != null
-        stateManager.loadState(state.toCore().copy(aceTokenConfigured = tokenConfigured))
+        val coreState = state.toCore()
+        stateManager.loadState(
+            coreState.copy(
+                aceTokenConfigured = tokenConfigured,
+                enableAutoRefactor = coreState.enableAutoRefactor && tokenConfigured,
+            ),
+        )
         if (legacyToken != null) {
             migrateLegacyAceAuthToken(legacyToken)
         }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/settings/tab/SettingsTab.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/settings/tab/SettingsTab.kt
@@ -24,8 +24,13 @@ class SettingsTab : BoundConfigurable(UiLabelsBundle.message("settingsTitle")) {
     private val scope = CoroutineScope(Dispatchers.IO)
     private var aceAuthToken by Delegates.observable("") { _, _, _ -> }
 
+    init {
+        scope.launch {
+            aceAuthToken = settingsStore.getAceAuthToken()
+        }
+    }
+
     override fun createPanel(): DialogPanel {
-        aceAuthToken = settingsStore.getAceAuthToken()
         return panel {
             row {
                 checkBox(UiLabelsBundle.message("enableCodeLenses"))
@@ -87,7 +92,9 @@ class SettingsTab : BoundConfigurable(UiLabelsBundle.message("settingsTitle")) {
     }
 
     override fun reset() {
-        aceAuthToken = settingsStore.getAceAuthToken()
+        scope.launch {
+            aceAuthToken = settingsStore.getAceAuthToken()
+        }
         super.reset()
     }
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/statusbar/AceStatusBarWidget.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/statusbar/AceStatusBarWidget.kt
@@ -1,5 +1,6 @@
 package com.codescene.jetbrains.platform.statusbar
 
+import com.codescene.jetbrains.core.util.shouldShowAceStatusIndicator
 import com.codescene.jetbrains.platform.listeners.AceStatusRefreshNotifier
 import com.codescene.jetbrains.platform.settings.CodeSceneGlobalSettingsStore
 import com.codescene.jetbrains.platform.util.Log
@@ -57,12 +58,13 @@ class AceStatusBarWidget : StatusBarWidget.IconPresentation, StatusBarWidget {
     }
 }
 
-internal class AceStatusBarWidgetFactory : StatusBarWidgetFactory {
+class AceStatusBarWidgetFactory : StatusBarWidgetFactory {
     override fun getId(): String = this::class.simpleName!!
 
     override fun getDisplayName(): String = ACE_STATUS
 
-    override fun isAvailable(project: Project): Boolean = true
+    override fun isAvailable(project: Project): Boolean =
+        shouldShowAceStatusIndicator(CodeSceneGlobalSettingsStore.getInstance().currentState())
 
     override fun canBeEnabledOn(statusBar: StatusBar): Boolean = true
 


### PR DESCRIPTION
Hides 3 buttons dynamically depending on the settings. The intent is to bias the feature towards being hidden unless it was already activated.

Tried out locally, works nicely.