### PR TITLE
Expose Code Health Monitor state for UI tests

### DIFF
--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/CwfUiTestDiagnostics.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/CwfUiTestDiagnostics.kt
@@ -26,3 +26,23 @@ fun markCwfInitializedForUiTests(
         component.accessibleContext.accessibleName = "CodeScene CWF initialized ${view.value}"
     }
 }
+
+fun markCodeHealthMonitorStateForUiTests(
+    project: Project,
+    activeJobCount: Int,
+    deltaResultCount: Int,
+) {
+    if (!isUiTestDiagnosticsEnabled()) return
+    val component = WebViewInitializer.getInstance(project).getBrowser(View.HOME)?.component ?: return
+    val state =
+        when {
+            activeJobCount > 0 -> "running"
+            deltaResultCount > 0 -> "has-results"
+            else -> "clean"
+        }
+    val marker = "CodeScene Code Health Monitor $state"
+    ApplicationManager.getApplication().invokeLater {
+        component.accessibleContext.accessibleDescription = marker
+        component.toolTipText = marker
+    }
+}

--- a/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/UpdateMonitor.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/webview/util/UpdateMonitor.kt
@@ -77,6 +77,7 @@ private fun updateMonitorImpl(project: Project) {
         ),
     )
     CwfMessageHandler.getInstance(project).postMessage(View.HOME, update.message)
+    markCodeHealthMonitorStateForUiTests(project, activeJobs.size, deltaResults.size)
 
     val elapsedTime = System.currentTimeMillis() - startTime
     Log.info("Completed updating monitor for project '${project.name}' in ${elapsedTime}ms", "UpdateMonitor")


### PR DESCRIPTION
Adds a test-only diagnostics marker for Code Health Monitor state so the external RemoteRobot UI test harness can observe monitor state without inspecting the JCEF DOM.

Why:
- RemoteRobot can observe the JCEF/Swing shell, but not Code Health Monitor content rendered inside CWF/JCEF.
- Existing DOM/text locators would create false confidence and likely flakes.
- This follows the existing CWF initialization diagnostics pattern.

What changed:
- Added markCodeHealthMonitorStateForUiTests(project, activeJobCount, deltaResultCount).
- Marker is gated behind -Dcodescene.uiTestDiagnostics=true.
- Marker values:
  - CodeScene Code Health Monitor clean
  - CodeScene Code Health Monitor running
  - CodeScene Code Health Monitor has-results
- The marker is written to accessibleDescription and toolTipText on the HOME browser component.
- Existing CWF init marker behavior is preserved; component.name and accessibleName are not changed.
- UpdateMonitor calls the marker after posting the HOME update.

Validation:
- ./gradlew ktlintCheck compileKotlin test --console=plain --warn passed.
- ./gradlew buildPlugin --console=plain --warn passed.

Scope:
- Testability seam only.
- No normal runtime behavior change unless codescene.uiTestDiagnostics=true.
- No UI test changes in this PR.