### PR TITLE
Add CWF important links bundle contract test

### DIFF
--- a/src/test/kotlin/com/codescene/jetbrains/platform/webview/CwfImportantLinksBundleTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/webview/CwfImportantLinksBundleTest.kt
@@ -1,0 +1,67 @@
+package com.codescene.jetbrains.platform.webview
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CwfImportantLinksBundleTest {
+    @Test
+    fun `cwf bundle contains important external links`() {
+        val bundle = readCwfBundle()
+
+        val expectedLinks =
+            listOf(
+                "Documentation" to "https://codescene.io/docs",
+                "Terms and Policies" to "https://codescene.com/policies",
+                "AI Privacy Principles" to "https://codescene.com/product/ace/principles",
+                "Contact CodeScene" to "https://codescene.com/company/contact-us",
+                "Help Center" to "https://helpcenter.codescene.com/",
+                "Report a Bug" to "https://forms.clickup.com/9015696197/f/8cp16u5-7955/P24KVTPFDHW9G36D17",
+            )
+
+        expectedLinks.forEach { (label, url) ->
+            assertContainsImportantLink(bundle, label, url)
+        }
+    }
+
+    private fun readCwfBundle(): String {
+        val bundlePath = findCwfBundlePath()
+
+        return Files.readString(bundlePath)
+    }
+
+    private fun findCwfBundlePath(): Path {
+        val candidateRoots =
+            listOfNotNull(
+                System.getenv("GITHUB_WORKSPACE")?.let { Path.of(it) },
+                Path.of(System.getProperty("user.dir")),
+            ).flatMap { root ->
+                generateSequence(root.toAbsolutePath()) { it.parent }.take(12).toList()
+            }.distinct()
+
+        val searchedPaths = candidateRoots.map { it.resolve(CWF_BUNDLE_PATH) }
+        return searchedPaths.firstOrNull { Files.isRegularFile(it) }
+            ?: error("Expected CWF bundle at one of: ${searchedPaths.joinToString()}")
+    }
+
+    private fun assertContainsImportantLink(
+        bundle: String,
+        label: String,
+        url: String,
+    ) {
+        val pattern =
+            Regex(
+                "label:\\s*\"" + Regex.escape(label) + "\"[\\s\\S]{0,300}?link:\\s*\"" + Regex.escape(url) + "\"",
+            )
+
+        assertTrue(
+            "Expected CWF bundle to contain important link [$label] -> [$url].",
+            pattern.containsMatchIn(bundle),
+        )
+    }
+
+    private companion object {
+        private val CWF_BUNDLE_PATH = Path.of("src/main/resources/cs-cwf/index.js")
+    }
+}


### PR DESCRIPTION
Adds a static contract test for important external links in the shipped CWF bundle.

Why:
- Covers FI-09 important link targets without brittle RemoteRobot/JCEF interaction.
- Plugin open-link routing, URL allowlisting, and telemetry are already covered by existing lower-layer tests.
- The remaining risk is that the shipped CWF bundle drops or misdirects important menu links.

What:
- Reads src/main/resources/cs-cwf/index.js directly.
- Verifies the tracked shipped bundle contains labels and targets for Documentation, Terms and Policies, AI Privacy Principles, Contact CodeScene, Help Center, and Report a Bug.

Validation:
- ./gradlew ktlintCheck :test --console=plain --warn

Scope:
- Test-only change.
- No runtime behavior changes.