### PR TITLE
Verify generated CWF important links

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -348,6 +348,60 @@ tasks.register("fetchCwf") {
     }
 }
 
+tasks.register("verifyCwfImportantLinks") {
+    group = "codescene assets"
+    description = "Verify important external links in the generated CWF bundle."
+
+    dependsOn("fetchCwf")
+
+    doLast {
+        val bundleFile = File("src/main/resources/cs-cwf/index.js")
+        if (!bundleFile.isFile) {
+            throw GradleException(
+                "Expected generated CWF bundle at ${bundleFile.absolutePath}. " +
+                    "Run fetchCwf before verifying CWF links.",
+            )
+        }
+
+        val bundle = bundleFile.readText()
+        val expectedLinks =
+            listOf(
+                "Documentation" to "https://codescene.io/docs",
+                "Terms and Policies" to "https://codescene.com/policies",
+                "AI Privacy Principles" to "https://codescene.com/product/ace/principles",
+                "Contact CodeScene" to "https://codescene.com/company/contact-us",
+                "Help Center" to "https://helpcenter.codescene.com/",
+                "Report a Bug" to (
+                    "https://forms.clickup.com/9015696197/f/" +
+                        "8cp16u5-7955/P24KVTPFDHW9G36D17"
+                ),
+            )
+
+        val objectPattern = Regex("""\{[^{}]{0,1500}}""")
+
+        expectedLinks.forEach { (label, url) ->
+            val labelPattern = Regex("""label\s*:\s*["']${Regex.escape(label)}["']""")
+            val linkPattern = Regex("""link\s*:\s*["']${Regex.escape(url)}["']""")
+            val hasMatchingObject =
+                objectPattern.findAll(bundle).any { match ->
+                    val item = match.value
+                    labelPattern.containsMatchIn(item) && linkPattern.containsMatchIn(item)
+                }
+
+            if (!hasMatchingObject) {
+                throw GradleException(
+                    "Expected generated CWF bundle to contain important link " +
+                        "[$label] -> [$url].",
+                )
+            }
+        }
+    }
+}
+
+tasks.named("buildPlugin") {
+    dependsOn("verifyCwfImportantLinks")
+}
+
 @Suppress("UNCHECKED_CAST")
 fun parseResponse(
     json: String,


### PR DESCRIPTION
Adds a generated-artifact contract check for important external links in the CWF bundle.

Why:
- Covers FI-09 important link targets at the artifact layer where the links actually exist.
- The CWF bundle is generated/downloaded into src/main/resources/cs-cwf and is ignored by git, so a normal JUnit/source test cannot verify it in CI.
- Checking labels or allowed domains alone would not cover the real risk: dropped or misdirected important links in the shipped CWF menu.

What:
- Adds verifyCwfImportantLinks Gradle task.
- The task depends on fetchCwf and verifies the generated CWF index.js contains the expected label→URL pairs.
- Wires the check into buildPlugin so build/release flows verify the generated bundle before packaging.

Validation:
- ./gradlew verifyCwfImportantLinks --console=plain --warn
- ./gradlew buildPlugin -PFEATURE_CWF_DEVMODE=false --console=plain --warn
- ./gradlew ktlintKotlinScriptCheck --console=plain --warn

Scope:
- Build-time verification only.
- No runtime behavior changes.