### PR TITLE
perf: reduce startup and idle CPU on large diff branches (CS-11659)

### DIFF
--- a/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/IDeltaCacheService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/contracts/IDeltaCacheService.kt
@@ -23,4 +23,9 @@ interface IDeltaCacheService {
     )
 
     fun getAll(): List<Pair<String, DeltaCacheItem>>
+
+    fun isCachedForCurrentContent(
+        filePath: String,
+        currentFileContent: String,
+    ): Boolean
 }

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/delta/DeltaCacheService.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/delta/DeltaCacheService.kt
@@ -131,5 +131,14 @@ open class DeltaCacheService(
             }
     }
 
+    open fun isCachedForCurrentContent(
+        filePath: String,
+        currentFileContent: String,
+    ): Boolean {
+        val entry = cache[key(filePath)] ?: return false
+        val currentHash = DigestUtils.sha256Hex(currentFileContent)
+        return entry.currentHash == currentHash
+    }
+
     override fun key(filePath: String): String = pathCacheKey(filePath)
 }

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/ChangedFilesScanState.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/ChangedFilesScanState.kt
@@ -1,0 +1,42 @@
+package com.codescene.jetbrains.core.git
+
+class ChangedFilesScanState {
+    var lastChangedFileSetKey: String? = null
+    var forceNextScan: Boolean = false
+
+    fun markDirty() {
+        forceNextScan = true
+    }
+
+    fun shouldSkipIdleScan(hadWorkspaceActivity: Boolean): Boolean =
+        !forceNextScan && !hadWorkspaceActivity && lastChangedFileSetKey != null
+
+    fun isUnchangedFileSet(changedFileSetKey: String): Boolean =
+        !forceNextScan && changedFileSetKey == lastChangedFileSetKey
+
+    fun recordScan(changedFileSetKey: String) {
+        forceNextScan = false
+        lastChangedFileSetKey = changedFileSetKey
+    }
+}
+
+fun serializeChangedFileSet(filePaths: Set<String>): String = filePaths.sorted().joinToString("\u0000")
+
+fun sortFilesByPriority(
+    filePaths: Set<String>,
+    visibleFiles: Set<String>,
+): List<String> {
+    val visibleKeys = visibleFiles.map { pathComparisonKey(it) }.toSet()
+    val visible = mutableListOf<String>()
+    val hidden = mutableListOf<String>()
+    for (filePath in filePaths) {
+        if (pathComparisonKey(filePath) in visibleKeys) {
+            visible.add(filePath)
+        } else {
+            hidden.add(filePath)
+        }
+    }
+    visible.sort()
+    hidden.sort()
+    return visible + hidden
+}

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitChangeObserver.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/GitChangeObserver.kt
@@ -31,7 +31,7 @@ class GitChangeObserver(
     private val eventQueue = mutableListOf<FileEvent>()
     private var scheduler: ScheduledExecutorService? = null
 
-    suspend fun populateTrackerFromRepoState() {
+    suspend fun populateTrackerFromRepoState(onReviewVisibleFile: suspend (String) -> Unit = {}) {
         logger.info("Populating tracker from repo state", "GitChangeObserver")
         synchronized(tracker) {
             tracker.clear()
@@ -39,13 +39,24 @@ class GitChangeObserver(
         val changedFiles = gitChangeLister.getAllChangedFiles(gitRootPath, workspacePath, emptySet())
         logger.info("getAllChangedFiles returned ${changedFiles.size} files", "GitChangeObserver")
         for (absolutePath in changedFiles) {
-            logger.info("Processing file: '$absolutePath'", "GitChangeObserver")
             synchronized(tracker) {
                 tracker.add(absolutePath)
             }
-            queueEvent(FileEvent(FileEventType.CHANGE, absolutePath))
         }
-        logger.info("Populated tracker with ${changedFiles.size} files", "GitChangeObserver")
+        val visibleFiles = openFilesObserver.getAllVisibleFileNames()
+        val visibleChanged =
+            changedFiles.filter { changedPath ->
+                val key = comparisonKey(changedPath)
+                visibleFiles.any { comparisonKey(it) == key }
+            }
+        for (absolutePath in sortFilesByPriority(visibleChanged.toSet(), visibleFiles)) {
+            logger.info("Scheduling startup review for visible file: '$absolutePath'", "GitChangeObserver")
+            onReviewVisibleFile(absolutePath)
+        }
+        logger.info(
+            "Populated tracker with ${changedFiles.size} files, scheduled ${visibleChanged.size} visible reviews",
+            "GitChangeObserver",
+        )
     }
 
     fun start() {

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/git/WorkspaceActivity.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/git/WorkspaceActivity.kt
@@ -1,0 +1,19 @@
+package com.codescene.jetbrains.core.git
+
+class WorkspaceActivity {
+    private var activitySinceLastScan = false
+
+    fun markWorkspaceFileActivity() {
+        activitySinceLastScan = true
+    }
+
+    fun consumeWorkspaceFileActivity(): Boolean {
+        val hadActivity = activitySinceLastScan
+        activitySinceLastScan = false
+        return hadActivity
+    }
+
+    fun reset() {
+        activitySinceLastScan = false
+    }
+}

--- a/core/src/main/kotlin/com/codescene/jetbrains/core/review/ReviewCacheProbe.kt
+++ b/core/src/main/kotlin/com/codescene/jetbrains/core/review/ReviewCacheProbe.kt
@@ -1,0 +1,18 @@
+package com.codescene.jetbrains.core.review
+
+import com.codescene.jetbrains.core.contracts.IDeltaCacheService
+import com.codescene.jetbrains.core.contracts.IReviewCacheService
+
+object ReviewCacheProbe {
+    fun isFullyCached(
+        filePath: String,
+        currentCode: String,
+        reviewCache: IReviewCacheService,
+        deltaCache: IDeltaCacheService,
+    ): Boolean {
+        if (reviewCache.get(ReviewCacheQuery(currentCode, filePath)) == null) {
+            return false
+        }
+        return deltaCache.isCachedForCurrentContent(filePath, currentCode)
+    }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/ChangedFilesScanStateTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/ChangedFilesScanStateTest.kt
@@ -1,0 +1,52 @@
+package com.codescene.jetbrains.core.git
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChangedFilesScanStateTest {
+    @Test
+    fun `idle scan is skipped when there was no activity and a previous scan exists`() {
+        val state = ChangedFilesScanState()
+        state.recordScan("a\u0000b")
+
+        assertTrue(state.shouldSkipIdleScan(hadWorkspaceActivity = false))
+    }
+
+    @Test
+    fun `idle scan runs after workspace activity`() {
+        val state = ChangedFilesScanState()
+        state.recordScan("a\u0000b")
+
+        assertFalse(state.shouldSkipIdleScan(hadWorkspaceActivity = true))
+    }
+
+    @Test
+    fun `markDirty forces scan even when idle`() {
+        val state = ChangedFilesScanState()
+        state.recordScan("a\u0000b")
+        state.markDirty()
+
+        assertFalse(state.shouldSkipIdleScan(hadWorkspaceActivity = false))
+    }
+
+    @Test
+    fun `unchanged file set is detected`() {
+        val state = ChangedFilesScanState()
+        state.recordScan(serializeChangedFileSet(setOf("/a.ts", "/b.ts")))
+
+        assertTrue(state.isUnchangedFileSet(serializeChangedFileSet(setOf("/b.ts", "/a.ts"))))
+    }
+
+    @Test
+    fun `sortFilesByPriority puts visible files first`() {
+        val sorted =
+            sortFilesByPriority(
+                setOf("/hidden.ts", "/visible.ts"),
+                setOf("/visible.ts"),
+            )
+
+        assertEquals(listOf("/visible.ts", "/hidden.ts"), sorted)
+    }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverPrePopulationTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/GitChangeObserverPrePopulationTest.kt
@@ -123,6 +123,23 @@ class GitChangeObserverPrePopulationTest {
         }
 
     @Test
+    fun `pre-population schedules review only for visible changed files`() =
+        runBlocking {
+            mockGitChangeLister.changedFiles =
+                setOf("$workspacePath/src/visible.ts", "$workspacePath/src/hidden.ts")
+            mockOpenFilesObserver.files = setOf("/workspace/src/visible.ts")
+
+            val reviewed = mutableListOf<String>()
+            val observer = createObserver()
+            observer.populateTrackerFromRepoState { reviewed.add(it) }
+
+            assertEquals(2, observer.getTrackedFiles().size)
+            assertEquals(1, reviewed.size)
+            assertTrue(reviewed.contains("/workspace/src/visible.ts"))
+            assertEquals(0, observer.getQueuedEventCount())
+        }
+
+    @Test
     fun `delete event fires for file that was open in editor when populateTrackerFromRepoState is called`() =
         runBlocking {
             mockGitChangeLister.changedFiles = setOf("$workspacePath/src/open-in-editor.ts")

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/git/WorkspaceActivityTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/git/WorkspaceActivityTest.kt
@@ -1,0 +1,16 @@
+package com.codescene.jetbrains.core.git
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WorkspaceActivityTest {
+    @Test
+    fun `activity is consumed once`() {
+        val activity = WorkspaceActivity()
+        activity.markWorkspaceFileActivity()
+
+        assertTrue(activity.consumeWorkspaceFileActivity())
+        assertFalse(activity.consumeWorkspaceFileActivity())
+    }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/review/ReviewCacheProbeTest.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/review/ReviewCacheProbeTest.kt
@@ -1,0 +1,71 @@
+package com.codescene.jetbrains.core.review
+
+import com.codescene.data.review.Review
+import com.codescene.jetbrains.core.delta.DeltaCacheEntry
+import com.codescene.jetbrains.core.testdoubles.InMemoryDeltaCacheService
+import com.codescene.jetbrains.core.testdoubles.InMemoryReviewCacheService
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReviewCacheProbeTest {
+    @Test
+    fun `isFullyCached returns true when review and delta caches match current content`() {
+        val reviewCache = InMemoryReviewCacheService()
+        val deltaCache = InMemoryDeltaCacheService()
+        val path = "/workspace/src/file.ts"
+        val currentCode = "current"
+        val baselineCode = "baseline"
+        val review = mockk<Review>()
+
+        reviewCache.put(
+            ReviewCacheEntry(
+                fileContents = currentCode,
+                filePath = path,
+                response = review,
+            ),
+        )
+        deltaCache.put(
+            DeltaCacheEntry(
+                filePath = path,
+                headContent = baselineCode,
+                currentFileContent = currentCode,
+                deltaApiResponse = null,
+            ),
+        )
+
+        assertTrue(
+            ReviewCacheProbe.isFullyCached(path, currentCode, reviewCache, deltaCache),
+        )
+    }
+
+    @Test
+    fun `isFullyCached returns false when delta cache content changed`() {
+        val reviewCache = InMemoryReviewCacheService()
+        val deltaCache = InMemoryDeltaCacheService()
+        val path = "/workspace/src/file.ts"
+        val currentCode = "current"
+        val review = mockk<Review>()
+
+        reviewCache.put(
+            ReviewCacheEntry(
+                fileContents = currentCode,
+                filePath = path,
+                response = review,
+            ),
+        )
+        deltaCache.put(
+            DeltaCacheEntry(
+                filePath = path,
+                headContent = "baseline",
+                currentFileContent = "old-current",
+                deltaApiResponse = null,
+            ),
+        )
+
+        assertFalse(
+            ReviewCacheProbe.isFullyCached(path, currentCode, reviewCache, deltaCache),
+        )
+    }
+}

--- a/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/InMemoryDeltaCacheService.kt
+++ b/core/src/test/kotlin/com/codescene/jetbrains/core/testdoubles/InMemoryDeltaCacheService.kt
@@ -36,4 +36,9 @@ class InMemoryDeltaCacheService : IDeltaCacheService {
     }
 
     override fun getAll(): List<Pair<String, DeltaCacheItem>> = delegate.getAll()
+
+    override fun isCachedForCurrentContent(
+        filePath: String,
+        currentFileContent: String,
+    ): Boolean = delegate.isCachedForCurrentContent(filePath, currentFileContent)
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/CachedReviewService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/CachedReviewService.kt
@@ -91,6 +91,21 @@ class CachedReviewService(
     }
 
     fun reviewByPath(filePath: String) {
+        schedulePathReview(filePath) { path, fileName ->
+            pathBasedReviewHandler.performCachedReviewByPath(path, fileName)
+        }
+    }
+
+    fun reviewByPathIfNeeded(filePath: String) {
+        schedulePathReview(filePath) { path, fileName ->
+            pathBasedReviewHandler.reviewByPathIfNeeded(path, fileName)
+        }
+    }
+
+    private fun schedulePathReview(
+        filePath: String,
+        performAction: suspend (String, String) -> Unit,
+    ) {
         if (!isPathSupportedForReview(project, filePath)) {
             return
         }
@@ -104,10 +119,10 @@ class CachedReviewService(
             timeout = 300_000,
             debounceDelayMs = null,
             showProgress = false,
-            performAction = { pathBasedReviewHandler.performCachedReviewByPath(filePath, fileName) },
+            performAction = { performAction(filePath, fileName) },
             onScheduled = null,
             onFinished = { onReviewFinished(filePath) },
-            onQueuedCallback = { reviewByPath(filePath) },
+            onQueuedCallback = { schedulePathReview(filePath, performAction) },
         )
     }
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/api/PathBasedReviewHandler.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/api/PathBasedReviewHandler.kt
@@ -4,6 +4,7 @@ import com.codescene.jetbrains.core.delta.DeltaCacheEntry
 import com.codescene.jetbrains.core.delta.DeltaCacheQuery
 import com.codescene.jetbrains.core.review.BaselineReviewCacheEntry
 import com.codescene.jetbrains.core.review.BaselineReviewCacheQuery
+import com.codescene.jetbrains.core.review.ReviewCacheProbe
 import com.codescene.jetbrains.core.review.ReviewCacheQuery
 import com.codescene.jetbrains.core.review.resolveDeltaExecutionPlan
 import com.codescene.jetbrains.core.review.resolveProgressMessage
@@ -30,44 +31,54 @@ class PathBasedReviewHandler(private val project: Project) {
         fun getInstance(project: Project): PathBasedReviewHandler = project.service<PathBasedReviewHandler>()
     }
 
+    suspend fun reviewByPathIfNeeded(
+        filePath: String,
+        fileName: String,
+    ) {
+        if (isFullyCachedForPath(filePath, fileName)) {
+            Log.info("reviewByPath skipped (fully cached) file=$fileName", "CodeSceneCachedReview")
+            return
+        }
+        performCachedReviewByPath(filePath, fileName)
+    }
+
+    suspend fun isFullyCachedForPath(
+        filePath: String,
+        fileName: String,
+    ): Boolean {
+        val currentCode = readCurrentCode(filePath, fileName) ?: return false
+        return ReviewCacheProbe.isFullyCached(
+            filePath,
+            currentCode,
+            serviceProvider.reviewCacheService,
+            serviceProvider.deltaCacheService,
+        )
+    }
+
     suspend fun performCachedReviewByPath(
         filePath: String,
         fileName: String,
     ) {
         val startTime = System.currentTimeMillis()
-        val file = LocalFileSystem.getInstance().findFileByPath(filePath)
-        if (file == null) {
-            Log.info("reviewByPath file not found file=$fileName", "CodeSceneCachedReview")
-            return
-        }
-
-        val fileReadStart = System.currentTimeMillis()
-        // Prefer document content (editor buffer) over VFS content (disk) when available.
-        // This prevents Code Health Monitor flickering when a file has unsaved changes:
-        // editor-triggered reviews use document.text while periodic polling would use disk content,
-        // causing the cache to flip-flop between fixed/unfixed states until the file is saved.
-        val currentCode =
-            ReadAction.compute<String?, Exception> {
-                if (!file.isValid) {
-                    return@compute null
-                }
-                val document: Document? = FileDocumentManager.getInstance().getDocument(file)
-                if (document != null) {
-                    Log.info("reviewByPath using document content file=$fileName", "CodeSceneCachedReview")
-                    document.text
-                } else {
-                    Log.info("reviewByPath falling back to VFS content file=$fileName", "CodeSceneCachedReview")
-                    String(file.contentsToByteArray(), file.charset)
-                }
-            }
+        val currentCode = readCurrentCode(filePath, fileName)
         if (currentCode == null) {
             Log.info("reviewByPath file became invalid file=$fileName", "CodeSceneCachedReview")
             return
         }
-        Log.info(
-            "reviewByPath fileRead took ${System.currentTimeMillis() - fileReadStart}ms file=$fileName",
-            "CodeSceneCachedReview",
-        )
+
+        if (ReviewCacheProbe.isFullyCached(
+                filePath,
+                currentCode,
+                serviceProvider.reviewCacheService,
+                serviceProvider.deltaCacheService,
+            )
+        ) {
+            Log.info(
+                "reviewByPath full cache hit file=$fileName totalTime=${System.currentTimeMillis() - startTime}ms",
+                "CodeSceneCachedReview",
+            )
+            return
+        }
 
         val cacheCheckStart = System.currentTimeMillis()
         val cachedReview = serviceProvider.reviewCacheService.get(ReviewCacheQuery(currentCode, filePath))
@@ -76,18 +87,6 @@ class PathBasedReviewHandler(private val project: Project) {
             "CodeSceneCachedReview",
         )
         if (cachedReview != null) {
-            val baselineCode = serviceProvider.gitService.getBranchCreationCommitCode(filePath)
-            val deltaQuery = DeltaCacheQuery(filePath, baselineCode, currentCode)
-            val (deltaHit, _) = serviceProvider.deltaCacheService.get(deltaQuery)
-
-            if (deltaHit) {
-                Log.info(
-                    "reviewByPath full cache hit file=$fileName totalTime=${System.currentTimeMillis() - startTime}ms",
-                    "CodeSceneCachedReview",
-                )
-                return
-            }
-
             Log.info(
                 "reviewByPath review cache hit, delta miss file=$fileName",
                 "CodeSceneCachedReview",
@@ -118,6 +117,40 @@ class PathBasedReviewHandler(private val project: Project) {
             "CodeSceneCachedReview",
         )
         handleDeltaByPath(filePath, fileName, currentCode, review.score.orElse(null), reviewMiss = true)
+    }
+
+    private fun readCurrentCode(
+        filePath: String,
+        fileName: String,
+    ): String? {
+        val file = LocalFileSystem.getInstance().findFileByPath(filePath)
+        if (file == null) {
+            Log.info("reviewByPath file not found file=$fileName", "CodeSceneCachedReview")
+            return null
+        }
+
+        val fileReadStart = System.currentTimeMillis()
+        val currentCode =
+            ReadAction.compute<String?, Exception> {
+                if (!file.isValid) {
+                    return@compute null
+                }
+                val document: Document? = FileDocumentManager.getInstance().getDocument(file)
+                if (document != null) {
+                    Log.info("reviewByPath using document content file=$fileName", "CodeSceneCachedReview")
+                    document.text
+                } else {
+                    Log.info("reviewByPath falling back to VFS content file=$fileName", "CodeSceneCachedReview")
+                    String(file.contentsToByteArray(), file.charset)
+                }
+            }
+        if (currentCode != null) {
+            Log.info(
+                "reviewByPath fileRead took ${System.currentTimeMillis() - fileReadStart}ms file=$fileName",
+                "CodeSceneCachedReview",
+            )
+        }
+        return currentCode
     }
 
     private suspend fun handleDeltaByPath(

--- a/src/main/kotlin/com/codescene/jetbrains/platform/delta/PlatformDeltaCacheService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/delta/PlatformDeltaCacheService.kt
@@ -88,4 +88,9 @@ class PlatformDeltaCacheService(
         super.setIncludeInCodeHealthMonitor(filePath, include)
         updateMonitor(project)
     }
+
+    override fun isCachedForCurrentContent(
+        filePath: String,
+        currentFileContent: String,
+    ): Boolean = super.isCachedForCurrentContent(filePath, currentFileContent)
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/CodesceneRepoFilesListener.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/CodesceneRepoFilesListener.kt
@@ -67,6 +67,8 @@ class CodesceneRepoFilesListener(
         refreshJob =
             scope.launch {
                 delay(DEBOUNCE_MS)
+                PeriodicChangeListerService.getInstance(project).markDirty()
+                PeriodicChangeListerService.getInstance(project).markWorkspaceFileActivity()
                 if (invalidateMainLineCache) {
                     mainLineBranchResolver.invalidate(gitRootPath)
                 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/Git4IdeaChangeLister.kt
@@ -66,6 +66,21 @@ class Git4IdeaChangeLister
 
         companion object {
             fun getInstance(project: Project): Git4IdeaChangeLister = project.service<Git4IdeaChangeLister>()
+
+            private const val CHANGED_FILES_CACHE_TTL_MS = 2000L
+        }
+
+        private data class CachedChangedFilesResult(
+            val files: Set<String>,
+            val expiresAtMs: Long,
+        )
+
+        private var cachedChangedFiles: CachedChangedFilesResult? = null
+        private var cachedChangedFilesKey: String? = null
+
+        fun invalidateChangedFilesCache() {
+            cachedChangedFiles = null
+            cachedChangedFilesKey = null
         }
 
         override suspend fun getAllChangedFiles(
@@ -73,6 +88,15 @@ class Git4IdeaChangeLister
             workspacePath: String,
             filesToExcludeFromHeuristic: Set<String>,
         ): Set<String> {
+            val cacheKey =
+                buildChangedFilesCacheKey(gitRootPath, workspacePath, filesToExcludeFromHeuristic)
+            val cached = getCachedChangedFiles(cacheKey)
+            if (cached != null) {
+                return cached
+            }
+
+            val now = System.currentTimeMillis()
+
             Log.info("Getting changed files gitRoot=${pathFileName(gitRootPath)}", "Git4IdeaChangeLister")
             val repository = getRepository(gitRootPath)
             if (repository == null) {
@@ -95,7 +119,32 @@ class Git4IdeaChangeLister
 
             val files = filesFromRepoState + filesFromGitDiff
             Log.info("Found ${files.size} changed files", "Git4IdeaChangeLister")
+            cachedChangedFiles = CachedChangedFilesResult(files, now + CHANGED_FILES_CACHE_TTL_MS)
+            cachedChangedFilesKey = cacheKey
             return files
+        }
+
+        private fun buildChangedFilesCacheKey(
+            gitRootPath: String,
+            workspacePath: String,
+            filesToExcludeFromHeuristic: Set<String>,
+        ): String =
+            listOf(
+                gitRootPath,
+                workspacePath,
+                filesToExcludeFromHeuristic.sorted().joinToString("\u0001"),
+            ).joinToString("\u0002")
+
+        private fun getCachedChangedFiles(cacheKey: String): Set<String>? {
+            val cached = cachedChangedFiles ?: return null
+            if (cachedChangedFilesKey != cacheKey) {
+                return null
+            }
+            if (System.currentTimeMillis() >= cached.expiresAtMs) {
+                return null
+            }
+            Log.info("Returning cached changed files count=${cached.files.size}", "Git4IdeaChangeLister")
+            return cached.files
         }
 
         private suspend fun collectFilesFromRepoState(

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitBranchChangeListener.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitBranchChangeListener.kt
@@ -1,0 +1,47 @@
+package com.codescene.jetbrains.platform.git
+
+import com.codescene.jetbrains.platform.util.Log
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.util.messages.MessageBusConnection
+import git4idea.repo.GitRepository
+import git4idea.repo.GitRepositoryChangeListener
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+
+class GitBranchChangeListener(
+    private val project: Project,
+    private val periodicChangeLister: PeriodicChangeListerService,
+    private val observer: GitChangeObserverAdapter?,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : Disposable {
+    private var connection: MessageBusConnection? = null
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    fun start() {
+        Log.info("Starting branch change listener", "GitBranchChangeListener")
+        connection?.disconnect()
+        connection = project.messageBus.connect(this)
+        connection?.subscribe(
+            GitRepository.GIT_REPO_CHANGE,
+            GitRepositoryChangeListener { repository ->
+                Log.info("Repository changed branch=${repository.currentBranchName}", "GitBranchChangeListener")
+                periodicChangeLister.markDirty()
+                periodicChangeLister.markWorkspaceFileActivity()
+                scope.launch {
+                    observer?.repopulateFromRepoState()
+                }
+            },
+        )
+    }
+
+    override fun dispose() {
+        connection?.disconnect()
+        connection = null
+        scope.cancel()
+    }
+}

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverAdapter.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverAdapter.kt
@@ -44,10 +44,10 @@ class GitChangeObserverAdapter(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    fun start() {
+    fun start(onReviewVisibleFile: suspend (String) -> Unit = {}) {
         Log.info("Starting async initialization", "GitChangeObserverAdapter")
         scope.launch {
-            observer.populateTrackerFromRepoState()
+            observer.populateTrackerFromRepoState(onReviewVisibleFile)
             Log.info("Tracker populated, starting scheduler", "GitChangeObserverAdapter")
             observer.start()
         }
@@ -65,7 +65,8 @@ class GitChangeObserverAdapter(
 
     fun getQueuedEventCount(): Int = observer.getQueuedEventCount()
 
-    suspend fun repopulateFromRepoState() = observer.populateTrackerFromRepoState()
+    suspend fun repopulateFromRepoState(onReviewVisibleFile: suspend (String) -> Unit = {}) =
+        observer.populateTrackerFromRepoState(onReviewVisibleFile)
 
     override fun dispose() {
         Log.info("Disposing, cancelling scope", "GitChangeObserverAdapter")

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitChangeObserverService.kt
@@ -4,6 +4,7 @@ import com.codescene.jetbrains.core.git.FileSystemAdapter
 import com.codescene.jetbrains.core.git.pathFileName
 import com.codescene.jetbrains.core.review.FileEventHandler
 import com.codescene.jetbrains.platform.api.CachedReviewService
+import com.codescene.jetbrains.platform.api.PathBasedReviewHandler
 import com.codescene.jetbrains.platform.di.CodeSceneProjectServiceProvider
 import com.codescene.jetbrains.platform.util.Log
 import com.codescene.jetbrains.platform.webview.util.updateMonitor
@@ -55,6 +56,7 @@ class GitChangeObserverService(
     private var repoStateListener: GitRepoStateListener? = null
     private var codesceneRepoFilesListener: CodesceneRepoFilesListener? = null
     private var gitIgnoreFilesListener: GitIgnoreFilesListener? = null
+    private var branchChangeListener: GitBranchChangeListener? = null
 
     fun start() {
         val workspacePath = project.basePath
@@ -70,6 +72,7 @@ class GitChangeObserverService(
         }
 
         val serviceProvider = CodeSceneProjectServiceProvider.getInstance(project)
+        val periodicChangeLister = PeriodicChangeListerService.getInstance(project)
         val fileEventHandler =
             FileEventHandler(
                 serviceProvider.deltaCacheService,
@@ -77,7 +80,7 @@ class GitChangeObserverService(
                 serviceProvider.baselineReviewCacheService,
             )
 
-        val tracker = SavedFilesTrackerAdapter(project)
+        val tracker = SavedFilesTrackerAdapter(project) { periodicChangeLister.markWorkspaceFileActivity() }
         tracker.start()
         savedFilesTracker = tracker
         Disposer.register(this, tracker)
@@ -101,11 +104,21 @@ class GitChangeObserverService(
         observer = gitChangeObserver
         Disposer.register(this, gitChangeObserver)
 
-        val bridge = VfsEventBridge(project, workspacePath, gitChangeObserver)
+        val bridge =
+            VfsEventBridge(project, workspacePath, gitChangeObserver) {
+                periodicChangeLister.markWorkspaceFileActivity()
+            }
         vfsEventBridge = bridge
         Disposer.register(this, bridge)
 
-        val listener = GitRepoStateListener(project, gitChangeObserver, workspacePath, gitRootPath)
+        val listener =
+            GitRepoStateListener(
+                project,
+                gitChangeObserver,
+                workspacePath,
+                gitRootPath,
+                periodicChangeLister,
+            )
         repoStateListener = listener
         Disposer.register(this, listener)
 
@@ -128,11 +141,21 @@ class GitChangeObserverService(
         gitIgnoreFilesListener = gitIgnoreListener
         Disposer.register(this, gitIgnoreListener)
 
+        val branchListener =
+            GitBranchChangeListener(
+                project,
+                periodicChangeLister,
+                gitChangeObserver,
+            )
+        branchChangeListener = branchListener
+        Disposer.register(this, branchListener)
+
         bridge.start()
         listener.start()
         repoFilesListener.start()
         gitIgnoreListener.start()
-        gitChangeObserver.start()
+        branchListener.start()
+        gitChangeObserver.start { filePath -> scheduleGitChangeReviewIfNeeded(project, filePath) }
     }
 
     private fun createGitChangeObserver(
@@ -180,7 +203,25 @@ class GitChangeObserverService(
         repoStateListener = null
         codesceneRepoFilesListener = null
         gitIgnoreFilesListener = null
+        branchChangeListener = null
         observer = null
+    }
+}
+
+internal fun scheduleGitChangeReviewIfNeeded(
+    project: Project,
+    filePath: String,
+) {
+    val fileName = pathFileName(filePath)
+    val reviewService = CachedReviewService.getInstance(project)
+    reviewService.scope.launch {
+        if (project.isDisposed) return@launch
+        val pathHandler = PathBasedReviewHandler.getInstance(project)
+        if (pathHandler.isFullyCachedForPath(filePath, fileName)) {
+            Log.info("Skipping cached file change path=$fileName", "GitChangeObserverService")
+            return@launch
+        }
+        scheduleGitChangeReview(project, filePath)
     }
 }
 

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitIgnoreFilesListener.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitIgnoreFilesListener.kt
@@ -59,6 +59,8 @@ class GitIgnoreFilesListener(
         refreshJob =
             scope.launch {
                 delay(DEBOUNCE_MS)
+                PeriodicChangeListerService.getInstance(project).markDirty()
+                PeriodicChangeListerService.getInstance(project).markWorkspaceFileActivity()
                 invalidateReviewCaches()
                 refreshReviews()
             }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/GitRepoStateListener.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/GitRepoStateListener.kt
@@ -25,6 +25,7 @@ class GitRepoStateListener(
     private val observer: GitChangeObserverAdapter,
     private val workspacePath: String,
     private val gitRootPath: String,
+    private val periodicChangeLister: PeriodicChangeListerService,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : Disposable {
     private var connection: MessageBusConnection? = null
@@ -40,6 +41,8 @@ class GitRepoStateListener(
                 override fun stagingAreaChanged(repository: GitRepository) {
                     if (pathComparisonKey(repository.root.path) == pathComparisonKey(gitRootPath)) {
                         Log.info("Staging area changed, scheduling reconciliation", "GitRepoStateListener")
+                        periodicChangeLister.markDirty()
+                        periodicChangeLister.markWorkspaceFileActivity()
                         scheduleReconciliation()
                     }
                 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/PeriodicChangeListerService.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/PeriodicChangeListerService.kt
@@ -1,7 +1,11 @@
 package com.codescene.jetbrains.platform.git
 
 import com.codescene.jetbrains.core.cleanup.StaleItemCleanup
+import com.codescene.jetbrains.core.git.ChangedFilesScanState
+import com.codescene.jetbrains.core.git.WorkspaceActivity
 import com.codescene.jetbrains.core.git.pathFileName
+import com.codescene.jetbrains.core.git.serializeChangedFileSet
+import com.codescene.jetbrains.core.git.sortFilesByPriority
 import com.codescene.jetbrains.platform.api.CachedReviewService
 import com.codescene.jetbrains.platform.delta.PlatformDeltaCacheService
 import com.codescene.jetbrains.platform.util.Log
@@ -47,10 +51,27 @@ class PeriodicChangeListerService(
     private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
     private var workspacePath: String? = null
     private var gitRootPath: String? = null
+    private var started = false
+    private val scanState = ChangedFilesScanState()
+    private val workspaceActivity = WorkspaceActivity()
     private val openFilesObserver = OpenFilesObserverAdapter(project)
     private val staleItemCleanup = StaleItemCleanup(PlatformDeltaCacheService.getInstance(project), Log)
 
+    fun markDirty() {
+        Log.info("Marking scan dirty", "PeriodicChangeListerService")
+        scanState.markDirty()
+        Git4IdeaChangeLister.getInstance(project).invalidateChangedFilesCache()
+    }
+
+    fun markWorkspaceFileActivity() {
+        workspaceActivity.markWorkspaceFileActivity()
+    }
+
     fun start() {
+        if (started) {
+            Log.info("Already started, skipping", "PeriodicChangeListerService")
+            return
+        }
         val wsPath = project.basePath
         if (wsPath == null) {
             Log.warn("Cannot start: project base path is null", "PeriodicChangeListerService")
@@ -72,29 +93,45 @@ class PeriodicChangeListerService(
             INTERVAL_MS,
             TimeUnit.MILLISECONDS,
         )
+        started = true
     }
 
     private fun pollChangedFiles() {
         val wsPath = workspacePath ?: return
         val gitRoot = gitRootPath ?: return
 
+        val hadWorkspaceActivity = workspaceActivity.consumeWorkspaceFileActivity()
+        if (scanState.shouldSkipIdleScan(hadWorkspaceActivity)) {
+            Log.info("Skipping idle poll tick", "PeriodicChangeListerService")
+            return
+        }
+
         val changeLister = Git4IdeaChangeLister.getInstance(project)
         val changedFiles = runBlocking { changeLister.getAllChangedFiles(gitRoot, wsPath, emptySet()) }
-        val visibleFiles = openFilesObserver.getAllVisibleFileNames()
+        val changedFileSetKey = serializeChangedFileSet(changedFiles)
 
+        val visibleFiles = openFilesObserver.getAllVisibleFileNames()
         val removed = staleItemCleanup.cleanupStaleItems(changedFiles, visibleFiles)
         if (removed.isNotEmpty()) {
             Log.info("Cleaned up ${removed.size} stale items", "PeriodicChangeListerService")
         }
 
+        if (scanState.isUnchangedFileSet(changedFileSetKey)) {
+            Log.info("Skipping poll: changed file set unchanged (${changedFiles.size} files)", "PeriodicChangeListerService")
+            return
+        }
+
+        scanState.recordScan(changedFileSetKey)
         Log.info("Poll found ${changedFiles.size} changed files", "PeriodicChangeListerService")
 
-        for (filePath in changedFiles) {
+        val sortedFiles = sortFilesByPriority(changedFiles, visibleFiles)
+        val reviewService = CachedReviewService.getInstance(project)
+        for (filePath in sortedFiles) {
             Log.info(
                 "Triggering review for: ${pathFileName(filePath)} fullPath=$filePath",
                 "PeriodicChangeListerService",
             )
-            CachedReviewService.getInstance(project).reviewByPath(filePath)
+            reviewService.reviewByPathIfNeeded(filePath)
         }
     }
 
@@ -107,5 +144,6 @@ class PeriodicChangeListerService(
     override fun dispose() {
         Log.info("Disposing", "PeriodicChangeListerService")
         scheduler.shutdown()
+        started = false
     }
 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/SavedFilesTrackerAdapter.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/SavedFilesTrackerAdapter.kt
@@ -13,6 +13,7 @@ import com.intellij.util.messages.MessageBusConnection
 
 class SavedFilesTrackerAdapter(
     private val project: Project,
+    private val onWorkspaceActivity: () -> Unit = {},
 ) : ISavedFilesTracker, Disposable {
     private var connection: MessageBusConnection? = null
 
@@ -40,6 +41,7 @@ class SavedFilesTrackerAdapter(
                     val file = FileDocumentManager.getInstance().getFile(document)
                     Log.info("Document saving file=${file?.name ?: "null"}", "SavedFilesTrackerAdapter")
                     if (file != null) {
+                        onWorkspaceActivity()
                         tracker.onFileSaved(file.path)
                     }
                 }

--- a/src/main/kotlin/com/codescene/jetbrains/platform/git/VfsEventBridge.kt
+++ b/src/main/kotlin/com/codescene/jetbrains/platform/git/VfsEventBridge.kt
@@ -19,6 +19,7 @@ class VfsEventBridge(
     private val project: Project,
     private val workspacePath: String,
     private val observer: GitChangeObserverAdapter,
+    private val onWorkspaceActivity: () -> Unit = {},
 ) : Disposable {
     private var connection: MessageBusConnection? = null
 
@@ -33,6 +34,7 @@ class VfsEventBridge(
                     var queuedCount = 0
                     for (event in events) {
                         val fileEvent = convertEvent(event) ?: continue
+                        onWorkspaceActivity()
                         observer.queueEvent(fileEvent)
                         queuedCount++
                     }

--- a/src/test/kotlin/com/codescene/jetbrains/platform/git/GitRepoStateListenerTest.kt
+++ b/src/test/kotlin/com/codescene/jetbrains/platform/git/GitRepoStateListenerTest.kt
@@ -26,6 +26,7 @@ import org.junit.Test
 class GitRepoStateListenerTest {
     private lateinit var project: Project
     private lateinit var observer: GitChangeObserverAdapter
+    private lateinit var periodicChangeLister: PeriodicChangeListerService
     private lateinit var listener: GitRepoStateListener
     private lateinit var messageBus: MessageBus
     private lateinit var connection: MessageBusConnection
@@ -38,13 +39,22 @@ class GitRepoStateListenerTest {
     fun setup() {
         project = mockk(relaxed = true)
         observer = mockk(relaxed = true)
+        periodicChangeLister = mockk(relaxed = true)
         messageBus = mockk(relaxed = true)
         connection = mockk(relaxed = true)
 
         every { project.messageBus } returns messageBus
         every { messageBus.connect(any<GitRepoStateListener>()) } returns connection
 
-        listener = GitRepoStateListener(project, observer, workspacePath, gitRootPath, testDispatcher)
+        listener =
+            GitRepoStateListener(
+                project,
+                observer,
+                workspacePath,
+                gitRootPath,
+                periodicChangeLister,
+                testDispatcher,
+            )
     }
 
     @After


### PR DESCRIPTION
## Summary
- Cap startup review flood by seeding the git tracker without queuing CHANGE for every changed file; review visible files first and defer the rest to the cache-aware 9s poller.
- Make periodic git polling cheap via idle skip, unchanged-file-set fingerprint, visible-first ordering, and markDirty on repo mutations (branch checkout, staging, config changes).
- Skip fully cached files before file read and git show; dedupe getAllChangedFiles within a 2s TTL.

Related: [CS-11659](https://app.clickup.com/t/86caeck3v) (JetBrains parity with VS Code [CS-11648](https://app.clickup.com/t/86cadvjj6)).

## Test plan
- [x] .\gradlew.bat test
- [x] CodeScene MCP pre_commit_code_health_safeguard
- [ ] Manual: open project on branch with many diffs vs main; confirm CPU drops after reviews settle and external changes still appear within ~9s

Made with [Cursor](https://cursor.com)