### PR TITLE
fix: restore webviews on IntelliJ 2026.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Fixed**
+  - Restore webviews on IntelliJ 2026.2 by declaring an optional JCEF dependency
+
 ### [0.5.3] - 2026-08-11
 - **Changed**
   - Verify generated CWF important links (#179)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,6 +174,7 @@ intellijPlatform {
         ides {
             create(IntelliJPlatformType.IntellijIdeaCommunity, "2024.3.7") { useInstaller = true }
             create(IntelliJPlatformType.IntellijIdea, "2025.3.2") { useInstaller = true }
+            create(IntelliJPlatformType.IntellijIdea, "2026.2.1") { useInstaller = true }
             select {
                 // 2026.1 and later
                 sinceBuild = "261"

--- a/src/main/resources/META-INF/codescene-jcef.xml
+++ b/src/main/resources/META-INF/codescene-jcef.xml
@@ -1,0 +1,2 @@
+<idea-plugin>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
     <vendor>CodeScene</vendor>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends optional="true" config-file="codescene-jcef.xml">com.intellij.modules.jcef</depends>
 
     <resource-bundle>messages.UiLabelsBundle</resource-bundle>
 


### PR DESCRIPTION
## Summary
- Declare an optional `com.intellij.modules.jcef` dependency so JCEF classes load on IntelliJ 2026.2, where the embedded browser was moved out of the platform core.
- Keep 2024.3+ compatibility by making the dependency optional (the JCEF module alias only exists from 2025.3.1).
- Add IntelliJ 2026.2.1 as a plugin verifier target.

## Test plan
- [ ] Install the plugin in IntelliJ 2026.2.1 and confirm the CodeScene tool window opens without `NoClassDefFoundError: JBCefApp`
- [ ] Confirm CWF docs/file editors open without `Cannot create editor by provider CwfDocsFileEditorProvider`
- [ ] Confirm the plugin still loads on IntelliJ 2024.3 (JCEF remains in the platform core)
